### PR TITLE
Fix embedded property resolution

### DIFF
--- a/src/main/java/io/github/perplexhub/rsql/RSQLJpaPredicateConverter.java
+++ b/src/main/java/io/github/perplexhub/rsql/RSQLJpaPredicateConverter.java
@@ -41,7 +41,10 @@ public class RSQLJpaPredicateConverter extends RSQLVisitorBase<Predicate, Root> 
 		Path<?> root = startRoot;
 		Attribute<?, ?> attribute = null;
 
-		for (String property : propertyPath.split("\\.")) {
+		String[] properties = propertyPath.split("\\.");
+		int deep = 0;
+
+		for (String property : properties) {
 			String mappedProperty = mapProperty(property, classMetadata.getJavaType());
 			if (!mappedProperty.equals(property)) {
 				RSQLJpaContext context = findPropertyPath(mappedProperty, root);
@@ -76,10 +79,13 @@ public class RSQLJpaPredicateConverter extends RSQLVisitorBase<Predicate, Root> 
 					if (isEmbeddedType(mappedProperty, classMetadata)) {
 						Class<?> embeddedType = findPropertyType(mappedProperty, classMetadata);
 						classMetadata = getManagedType(embeddedType);
+						attribute = classMetadata.getAttribute(properties[deep + 1]);
+					} else {
+						attribute = classMetadata.getAttribute(property);
 					}
-					attribute = classMetadata.getAttribute(property);
 				}
 			}
+			deep++;
 		}
 		return RSQLJpaContext.of(root, attribute);
 	}


### PR DESCRIPTION
When using embedded types, use not the name of the property being evaluated, but the later one.

If we use expression `embeddedFoo.bar==x`, we have to get the "bar" property from the "Foo" embedded class, instead of resolving current name property: `classMetadata.getAttribute(property)`