### PR TITLE
List of abstract support

### DIFF
--- a/rsql-common/pom.xml
+++ b/rsql-common/pom.xml
@@ -10,6 +10,11 @@
 	<name>io.github.perplexhub - RSQL-Common</name>
 	<dependencies>
 		<dependency>
+			<groupId>org.reflections</groupId>
+			<artifactId>reflections</artifactId>
+			<version>0.9.12</version>
+		</dependency>
+		<dependency>
 			<groupId>cz.jirutka.rsql</groupId>
 			<artifactId>rsql-parser</artifactId>
 		</dependency>

--- a/rsql-common/src/test/java/io/github/perplexhub/rsql/model/AdminProject.java
+++ b/rsql-common/src/test/java/io/github/perplexhub/rsql/model/AdminProject.java
@@ -1,0 +1,18 @@
+package io.github.perplexhub.rsql.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@DiscriminatorValue("Administrative")
+@Entity
+@Data
+public class AdminProject extends Project {
+
+    private String departmentName;
+}

--- a/rsql-common/src/test/java/io/github/perplexhub/rsql/model/DesignProject.java
+++ b/rsql-common/src/test/java/io/github/perplexhub/rsql/model/DesignProject.java
@@ -1,0 +1,18 @@
+package io.github.perplexhub.rsql.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@DiscriminatorValue("Design")
+@Entity
+@Data
+public class DesignProject extends Project {
+
+    private String companyName;
+}

--- a/rsql-common/src/test/java/io/github/perplexhub/rsql/model/Project.java
+++ b/rsql-common/src/test/java/io/github/perplexhub/rsql/model/Project.java
@@ -1,0 +1,21 @@
+package io.github.perplexhub.rsql.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name = "Type")
+public abstract class Project {
+
+    @Id
+    private Integer id;
+
+    private String name;
+}

--- a/rsql-common/src/test/java/io/github/perplexhub/rsql/model/User.java
+++ b/rsql-common/src/test/java/io/github/perplexhub/rsql/model/User.java
@@ -34,4 +34,7 @@ public class User {
 	@Enumerated(EnumType.STRING)
 	private Status status = Status.STARTED;
 
+	@JoinColumn(name = "user_id")
+	@OneToMany(fetch = FetchType.EAGER, cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<Project> projects;
 }

--- a/rsql-common/src/test/resources/application.properties
+++ b/rsql-common/src/test/resources/application.properties
@@ -7,7 +7,7 @@ hibernate.dialect=org.hibernate.dialect.H2Dialect
 hibernate.show_sql=true
 hibernate.hbm2ddl.auto=create-drop
 
-spring.jpa.properties.hibernate.hbm2ddl.import_files=import_company.sql,import_user.sql,import_role.sql,import_user_role.sql
+spring.jpa.properties.hibernate.hbm2ddl.import_files=import_company.sql,import_user.sql,import_role.sql,import_user_role.sql,import_project.sql
 
 logging.level.io.github.perplexhub.rsql=DEBUG
 logging.level.org.hibernate.SQL=TRACE

--- a/rsql-common/src/test/resources/import_project.sql
+++ b/rsql-common/src/test/resources/import_project.sql
@@ -1,0 +1,2 @@
+insert into project(id, user_id, type, name, department_name, company_name) values(1, 1, 'Administrative', 'someProjectName', 'someDepartmentName', null);
+insert into project(id, user_id, type, name, department_name, company_name) values(2, 1, 'Design', 'someProjectName', null, 'someCompany');

--- a/rsql-jpa/src/main/java/io/github/perplexhub/rsql/RSQLJPAPredicateConverter.java
+++ b/rsql-jpa/src/main/java/io/github/perplexhub/rsql/RSQLJPAPredicateConverter.java
@@ -57,7 +57,7 @@ public class RSQLJPAPredicateConverter extends RSQLVisitorBase<Predicate, Root> 
             } else {
                 if (!hasPropertyName(mappedProperty, classMetadata)) {
                     if (Modifier.isAbstract(classMetadata.getJavaType().getModifiers())) {
-                        Optional<Class<?>> foundSubClass = (Optional<Class<?>>) new Reflections("")
+                        Optional<Class<?>> foundSubClass = (Optional<Class<?>>) new Reflections(classMetadata.getJavaType().getPackage().getName())
                                 .getSubTypesOf(classMetadata.getJavaType())
                                 .stream()
                                 .filter(subType -> hasPropertyName(mappedProperty, getManagedType(subType)))
@@ -66,7 +66,9 @@ public class RSQLJPAPredicateConverter extends RSQLVisitorBase<Predicate, Root> 
                             classMetadata = getManagedType(foundSubClass.get());
                             root = root instanceof Join ? builder.treat((Join) root, foundSubClass.get()).get(property) : builder.treat((Path) root, foundSubClass.get()).get(property);
                             attribute = classMetadata.getAttribute(property);
-                        }
+                        } else {
+							throw new IllegalArgumentException("Unknown property: " + mappedProperty + " from entity " + classMetadata.getJavaType().getName());
+						}
                     } else {
                         throw new IllegalArgumentException("Unknown property: " + mappedProperty + " from entity " + classMetadata.getJavaType().getName());
                     }

--- a/rsql-jpa/src/main/java/io/github/perplexhub/rsql/RSQLJPAPredicateConverter.java
+++ b/rsql-jpa/src/main/java/io/github/perplexhub/rsql/RSQLJPAPredicateConverter.java
@@ -2,6 +2,7 @@ package io.github.perplexhub.rsql;
 
 import static io.github.perplexhub.rsql.RSQLOperators.*;
 
+import java.lang.reflect.Modifier;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -17,6 +18,7 @@ import cz.jirutka.rsql.parser.ast.ComparisonOperator;
 import cz.jirutka.rsql.parser.ast.OrNode;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.reflections.Reflections;
 
 @Slf4j
 @SuppressWarnings({ "rawtypes", "unchecked" })
@@ -46,51 +48,64 @@ public class RSQLJPAPredicateConverter extends RSQLVisitorBase<Predicate, Root> 
 
 		String[] properties = propertyPath.split("\\.");
 
-		for (String property : properties) {
-			String mappedProperty = mapProperty(property, classMetadata.getJavaType());
-			if (!mappedProperty.equals(property)) {
-				RSQLJPAContext context = findPropertyPath(mappedProperty, root);
-				root = context.getPath();
-				attribute = context.getAttribute();
-			} else {
-				if (!hasPropertyName(mappedProperty, classMetadata)) {
-					throw new IllegalArgumentException("Unknown property: " + mappedProperty + " from entity " + classMetadata.getJavaType().getName());
-				}
+        for (String property : properties) {
+            String mappedProperty = mapProperty(property, classMetadata.getJavaType());
+            if (!mappedProperty.equals(property)) {
+                RSQLJPAContext context = findPropertyPath(mappedProperty, root);
+                root = context.getPath();
+                attribute = context.getAttribute();
+            } else {
+                if (!hasPropertyName(mappedProperty, classMetadata)) {
+                    if (Modifier.isAbstract(classMetadata.getJavaType().getModifiers())) {
+                        Optional<Class<?>> foundSubClass = (Optional<Class<?>>) new Reflections("")
+                                .getSubTypesOf(classMetadata.getJavaType())
+                                .stream()
+                                .filter(subType -> hasPropertyName(mappedProperty, getManagedType(subType)))
+                                .findFirst();
+                        if (foundSubClass.isPresent()) {
+                            classMetadata = getManagedType(foundSubClass.get());
+                            root = root instanceof Join ? builder.treat((Join) root, foundSubClass.get()).get(property) : builder.treat((Path) root, foundSubClass.get()).get(property);
+                            attribute = classMetadata.getAttribute(property);
+                        }
+                    } else {
+                        throw new IllegalArgumentException("Unknown property: " + mappedProperty + " from entity " + classMetadata.getJavaType().getName());
+                    }
+                } else {
+                    if (isAssociationType(mappedProperty, classMetadata)) {
+                        boolean isOneToAssociationType = isOneToOneAssociationType(mappedProperty, classMetadata) || isOneToManyAssociationType(mappedProperty, classMetadata);
+                        Class<?> associationType = findPropertyType(mappedProperty, classMetadata);
+                        type = associationType;
+                        String previousClass = classMetadata.getJavaType().getName();
+                        classMetadata = getManagedType(associationType);
 
-				if (isAssociationType(mappedProperty, classMetadata)) {
-					boolean isOneToAssociationType = isOneToOneAssociationType(mappedProperty, classMetadata) || isOneToManyAssociationType(mappedProperty, classMetadata);
-					Class<?> associationType = findPropertyType(mappedProperty, classMetadata);
-					type = associationType;
-					String previousClass = classMetadata.getJavaType().getName();
-					classMetadata = getManagedType(associationType);
+                        String keyJoin = root.getJavaType().getSimpleName().concat(".").concat(mappedProperty);
+                        log.debug("Create a join between [{}] and [{}] using key [{}]", previousClass, classMetadata.getJavaType().getName(), keyJoin);
+                        root = isOneToAssociationType ? joinLeft(keyJoin, root, mappedProperty) : join(keyJoin, root, mappedProperty);
+                    } else if (isElementCollectionType(mappedProperty, classMetadata)) {
+                        String previousClass = classMetadata.getJavaType().getName();
+                        attribute = classMetadata.getAttribute(property);
+                        classMetadata = getManagedElementCollectionType(mappedProperty, classMetadata);
 
-					String keyJoin = root.getJavaType().getSimpleName().concat(".").concat(mappedProperty);
-					log.debug("Create a join between [{}] and [{}] using key [{}]", previousClass, classMetadata.getJavaType().getName(), keyJoin);
-					root = isOneToAssociationType ? joinLeft(keyJoin, root, mappedProperty) : join(keyJoin, root, mappedProperty);
-				} else if (isElementCollectionType(mappedProperty, classMetadata)) {
-					String previousClass = classMetadata.getJavaType().getName();
-					attribute = classMetadata.getAttribute(property);
-					classMetadata = getManagedElementCollectionType(mappedProperty, classMetadata);
+                        String keyJoin = root.getJavaType().getSimpleName().concat(".").concat(mappedProperty);
+                        log.debug("Create a element collection join between [{}] and [{}] using key [{}]", previousClass, classMetadata.getJavaType().getName(), keyJoin);
+                        root = join(keyJoin, root, mappedProperty);
+                    } else {
+                        log.debug("Create property path for type [{}] property [{}]", classMetadata.getJavaType().getName(), mappedProperty);
+                        root = root.get(mappedProperty);
 
-					String keyJoin = root.getJavaType().getSimpleName().concat(".").concat(mappedProperty);
-					log.debug("Create a element collection join between [{}] and [{}] using key [{}]", previousClass, classMetadata.getJavaType().getName(), keyJoin);
-					root = join(keyJoin, root, mappedProperty);
-				} else {
-					log.debug("Create property path for type [{}] property [{}]", classMetadata.getJavaType().getName(), mappedProperty);
-					root = root.get(mappedProperty);
-
-					if (isEmbeddedType(mappedProperty, classMetadata)) {
-						Class<?> embeddedType = findPropertyType(mappedProperty, classMetadata);
-						type = embeddedType;
-						classMetadata = getManagedType(embeddedType);
-					} else {
-						attribute = classMetadata.getAttribute(property);
-					}
-				}
-			}
-		}
-		accessControl(type, attribute.getName());
-		return RSQLJPAContext.of(root, attribute);
+                        if (isEmbeddedType(mappedProperty, classMetadata)) {
+                            Class<?> embeddedType = findPropertyType(mappedProperty, classMetadata);
+                            type = embeddedType;
+                            classMetadata = getManagedType(embeddedType);
+                        } else {
+                            attribute = classMetadata.getAttribute(property);
+                        }
+                    }
+                }
+            }
+        }
+        accessControl(type, attribute.getName());
+        return RSQLJPAContext.of(root, attribute);
 	}
 
 	protected Path<?> join(String keyJoin, Path<?> root, String mappedProperty) {

--- a/rsql-jpa/src/test/java/io/github/perplexhub/rsql/RSQLJPASupportTest.java
+++ b/rsql-jpa/src/test/java/io/github/perplexhub/rsql/RSQLJPASupportTest.java
@@ -763,6 +763,13 @@ public class RSQLJPASupportTest {
 			.containsExactly(3, 4, 5, 1, 2, 10, 11, 12, 9, 7, 8, 6);
 	}
 
+	@Test
+	public void testFindingUserByProjectImplAttribute() {
+		Specification specification = RSQLJPASupport.toSpecification("projects.departmentName==someDepartmentName");
+		List<User> foundUsers = userRepository.findAll(specification);
+		Assertions.assertThat(foundUsers).extracting(User::getId).containsExactly(1);
+	}
+
 	@Before
 	public void setUp() throws Exception {
 		getPropertyWhitelist().clear();

--- a/rsql-jpa/src/test/java/io/github/perplexhub/rsql/RSQLJPASupportTest.java
+++ b/rsql-jpa/src/test/java/io/github/perplexhub/rsql/RSQLJPASupportTest.java
@@ -765,7 +765,7 @@ public class RSQLJPASupportTest {
 
 	@Test
 	public void testFindingUserByProjectImplAttribute() {
-		Specification specification = RSQLJPASupport.toSpecification("projects.departmentName==someDepartmentName");
+		Specification specification = RSQLJPASupport.toSpecification("projects.departmentName==someDepartmentName", true);
 		List<User> foundUsers = userRepository.findAll(specification);
 		Assertions.assertThat(foundUsers).extracting(User::getId).containsExactly(1);
 	}


### PR DESCRIPTION
As a follow up for [this issue](https://github.com/perplexhub/rsql-jpa-specification/issues/43).

Now, if the desired field is not present in the root, and the root is an abstract class, the lib finds the first implementation of the abstract class that have the desired field, and uses that as a new treated root.

Scenario built using `Project`, `AdminProject` and `DesignProject` classes.
Scenario tested on `RSQLJPASupportTest.java` on method `testFindingUserByProjectImplAttribute`.