### PR TITLE
Change getPropertyPathMapper to protected

### DIFF
--- a/rsql-common/src/main/java/io/github/perplexhub/rsql/RSQLVisitorBase.java
+++ b/rsql-common/src/main/java/io/github/perplexhub/rsql/RSQLVisitorBase.java
@@ -43,7 +43,7 @@ public abstract class RSQLVisitorBase<R, A> implements RSQLVisitor<R, A> {
 		return entityManagerMap != null ? entityManagerMap : Collections.emptyMap();
 	}
 
-	abstract Map<String, String> getPropertyPathMapper();
+	protected abstract Map<String, String> getPropertyPathMapper();
 
 	public Map<Class<?>, Map<String, String>> getPropertyRemapping() {
 		return propertyRemapping != null ? propertyRemapping : Collections.emptyMap();


### PR DESCRIPTION
Hello. I'm evaluating your library and so far am pretty happy with the functionality within JPA 👍  I'm also prototyping a visitor class that can generate WHERE clauses for native SQL. I thought it would be nice to extend `RSQLVisitorBase` to get access to the type conversion and access control functionality, but I'm unable to do so outside of the `io.github.perplexhub.rsql` package due to this one method being package-private. 

Thoughts?