### PR TITLE
Handle malformed sort query

### DIFF
--- a/rsql-jpa/src/main/java/io/github/perplexhub/rsql/SortUtils.java
+++ b/rsql-jpa/src/main/java/io/github/perplexhub/rsql/SortUtils.java
@@ -1,9 +1,9 @@
 package io.github.perplexhub.rsql;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import javax.persistence.criteria.CriteriaBuilder;
@@ -15,16 +15,16 @@ import org.springframework.lang.Nullable;
 
 class SortUtils {
 
-    private static final String MULTIPLE_SORT_SEPARATOR = ";";
-    private static final String SORT_SEPARATOR = ",";
+    private static final Pattern MULTIPLE_SORT_SEPARATOR = Pattern.compile(";");
+    private static final Pattern SORT_SEPARATOR = Pattern.compile(",");
 
     static List<Order> parseSort(@Nullable final String sort, final Map<String, String> propertyMapper, final Root<?> root, final CriteriaBuilder cb) {
         if (sort == null) {
             return new ArrayList<>();
         }
 
-        return Arrays.stream(sort.split(MULTIPLE_SORT_SEPARATOR))
-            .map(item -> item.split(SORT_SEPARATOR))
+        return MULTIPLE_SORT_SEPARATOR.splitAsStream(sort)
+            .map(SORT_SEPARATOR::split)
             .map(parts -> sortToJpaOrder(parts, propertyMapper, root, cb))
             .collect(Collectors.toList());
     }

--- a/rsql-jpa/src/main/java/io/github/perplexhub/rsql/SortUtils.java
+++ b/rsql-jpa/src/main/java/io/github/perplexhub/rsql/SortUtils.java
@@ -12,6 +12,7 @@ import javax.persistence.criteria.Order;
 import javax.persistence.criteria.Root;
 
 import org.springframework.lang.Nullable;
+import org.springframework.util.StringUtils;
 
 class SortUtils {
 
@@ -24,9 +25,16 @@ class SortUtils {
         }
 
         return MULTIPLE_SORT_SEPARATOR.splitAsStream(sort)
-            .map(SORT_SEPARATOR::split)
+            .map(SortUtils::split)
+            .filter(parts -> parts.length > 0)
             .map(parts -> sortToJpaOrder(parts, propertyMapper, root, cb))
             .collect(Collectors.toList());
+    }
+
+    private static String[] split(String sort) {
+        return SORT_SEPARATOR.splitAsStream(sort)
+            .filter(StringUtils::hasText)
+            .toArray(String[]::new);
     }
 
     @SuppressWarnings("unchecked")

--- a/rsql-jpa/src/test/java/io/github/perplexhub/rsql/RSQLJPASupportTest.java
+++ b/rsql-jpa/src/test/java/io/github/perplexhub/rsql/RSQLJPASupportTest.java
@@ -833,6 +833,15 @@ public class RSQLJPASupportTest {
 			.extracting(User::getId)
 			.containsExactly(1, 2, 3, 4, 5);
 	}
+	
+	@Test
+	public void testWithMalformedSort() {
+		Page<User> users = userRepository.findAll(toSort(";;,;,,;"), PageRequest.of(0, 1));
+
+		Assertions.assertThat(users.getContent())
+			.extracting(User::getId)
+			.containsExactly(1);
+	}
 
 	@Test
 	public void testSortUsersByIdDesc() {


### PR DESCRIPTION
This PR provides fixes for parsing malformed sort queries like `;;,;,,;`