### PR TITLE
Flag to control equality operators with string arguments.

### DIFF
--- a/rsql-common/src/test/java/io/github/perplexhub/rsql/model/User.java
+++ b/rsql-common/src/test/java/io/github/perplexhub/rsql/model/User.java
@@ -17,6 +17,7 @@ import lombok.NoArgsConstructor;
 public class User {
 
 	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Integer id;
 
 	private String name;

--- a/rsql-jpa/src/main/java/io/github/perplexhub/rsql/QuerySupport.java
+++ b/rsql-jpa/src/main/java/io/github/perplexhub/rsql/QuerySupport.java
@@ -12,6 +12,11 @@ import java.util.Map;
 public class QuerySupport {
     private String rsqlQuery;
     private boolean distinct;
+    /**
+     * Whether try to interpret {@link RSQLOperators#EQUAL} or {@link RSQLOperators#NOT_EQUAL} operators as
+     * {@link RSQLOperators#LIKE}, {@link RSQLOperators#NOT_LIKE} or their case-insensitive variants.
+     */
+    private boolean strictEquality;
     private Map<String, String> propertyPathMapper;
     private List<RSQLCustomPredicate<?>> customPredicates;
     private Map<String, JoinType> joinHints;


### PR DESCRIPTION
This PR introduces new `strictEquality` flag. Currently, we replace '*' characters with '%' and completely remove '^' character from the string when used in conjunction with `==` or `!=` operators. Then we form a `LIKE` or case-insensitive clause depending on occurrence of `*` and `^`. If users actually have such characters in the queried column they get results not strictly equal but results of "LIKE" query.

The `strictEquality` will give control to prevent or allow such EQUAL -> LIKE conversions. The default value is false to preserve existing behavior.