### PR TITLE
Include attribute in RSQLCustomPredicateInput.

### DIFF
--- a/rsql-common/src/main/java/io/github/perplexhub/rsql/RSQLCustomPredicateInput.java
+++ b/rsql-common/src/main/java/io/github/perplexhub/rsql/RSQLCustomPredicateInput.java
@@ -5,15 +5,25 @@ import java.util.List;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.From;
 import javax.persistence.criteria.Path;
+import javax.persistence.metamodel.Attribute;
 
 import lombok.Value;
 
 @Value(staticConstructor = "of")
 public class RSQLCustomPredicateInput {
 
-	private CriteriaBuilder criteriaBuilder;
-	private Path<?> path;
-	private List<Object> arguments;
-	private From root;
+  CriteriaBuilder criteriaBuilder;
+  Path<?> path;
+  Attribute<?, ?> attribute;
+  List<Object> arguments;
+  From<?, ?> root;
 
+  /**
+   * @deprecated Please use {@link RSQLCustomPredicateInput#of(CriteriaBuilder, Path, Attribute, List, From)} instead.
+   */
+  @Deprecated
+  public static RSQLCustomPredicateInput of(CriteriaBuilder criteriaBuilder, Path<?> path, List<Object> arguments,
+																						From<?, ?> root) {
+    return of(criteriaBuilder, path, null, arguments, root);
+  }
 }

--- a/rsql-jpa/src/main/java/io/github/perplexhub/rsql/RSQLJPAPredicateConverter.java
+++ b/rsql-jpa/src/main/java/io/github/perplexhub/rsql/RSQLJPAPredicateConverter.java
@@ -176,7 +176,7 @@ public class RSQLJPAPredicateConverter extends RSQLVisitorBase<Predicate, From> 
 			for (String argument : node.getArguments()) {
 				arguments.add(convert(argument, customPredicate.getType()));
 			}
-			return customPredicate.getConverter().apply(RSQLCustomPredicateInput.of(builder, attrPath, holder.getAttribute(), arguments, root));
+			return customPredicate.getConverter().apply(RSQLCustomPredicateInput.of(builder, attrPath, attribute, arguments, root));
 		}
 
 		Class type = attribute != null ? attribute.getJavaType() : null;

--- a/rsql-jpa/src/main/java/io/github/perplexhub/rsql/RSQLJPAPredicateConverter.java
+++ b/rsql-jpa/src/main/java/io/github/perplexhub/rsql/RSQLJPAPredicateConverter.java
@@ -168,6 +168,7 @@ public class RSQLJPAPredicateConverter extends RSQLVisitorBase<Predicate, From> 
 		ComparisonOperator op = node.getOperator();
 		RSQLJPAContext holder = findPropertyPath(node.getSelector(), root);
 		Path attrPath = holder.getPath();
+		Attribute attribute = holder.getAttribute();
 
 		if (customPredicates.containsKey(op)) {
 			RSQLCustomPredicate<?> customPredicate = customPredicates.get(op);
@@ -175,10 +176,9 @@ public class RSQLJPAPredicateConverter extends RSQLVisitorBase<Predicate, From> 
 			for (String argument : node.getArguments()) {
 				arguments.add(convert(argument, customPredicate.getType()));
 			}
-			return customPredicate.getConverter().apply(RSQLCustomPredicateInput.of(builder, attrPath, arguments, root));
+			return customPredicate.getConverter().apply(RSQLCustomPredicateInput.of(builder, attrPath, holder.getAttribute(), arguments, root));
 		}
 
-		Attribute attribute = holder.getAttribute();
 		Class type = attribute != null ? attribute.getJavaType() : null;
 		if (attribute != null) {
 			if (attribute.getPersistentAttributeType() == PersistentAttributeType.ELEMENT_COLLECTION) {


### PR DESCRIPTION
When defining custom predicates sometimes users need to access attribute either for diagnostics or fine-tuning.