### PR TITLE
Locating Auto-configuration Candidates in Spring Boot 3 style. 

### DIFF
--- a/rsql-jpa-spring-boot-starter/src/main/resources/META-INF/spring.factories
+++ b/rsql-jpa-spring-boot-starter/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-io.github.perplexhub.rsql.RSQLJPAAutoConfiguration

--- a/rsql-jpa-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/rsql-jpa-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+io.github.perplexhub.rsql.RSQLJPAAutoConfiguration

--- a/rsql-querydsl-spring-boot-starter/src/main/resources/META-INF/spring.factories
+++ b/rsql-querydsl-spring-boot-starter/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-io.github.perplexhub.rsql.RSQLQueryDSLAutoConfiguration

--- a/rsql-querydsl-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/rsql-querydsl-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+io.github.perplexhub.rsql.RSQLQueryDSLAutoConfiguration


### PR DESCRIPTION
[Reference](https://docs.spring.io/spring-boot/docs/3.0.1/reference/htmlsingle/#features.developing-auto-configuration.locating-auto-configuration-candidates)