### PR TITLE
Join reuse improvements to help with JPA fetches

### DIFF
--- a/rsql-jpa/src/main/java/io/github/perplexhub/rsql/JoinUtils.java
+++ b/rsql-jpa/src/main/java/io/github/perplexhub/rsql/JoinUtils.java
@@ -1,0 +1,54 @@
+package io.github.perplexhub.rsql;
+
+import javax.persistence.criteria.Fetch;
+import javax.persistence.criteria.From;
+import javax.persistence.criteria.Join;
+import javax.persistence.criteria.JoinType;
+
+final class JoinUtils {
+
+    private JoinUtils() {
+    }
+
+    public static <X, Z> Join<X, ?> getOrCreateJoin(
+            final From<Z, X> root, final String attribute, final JoinType joinType) {
+        final Join<X, ?> join = getJoin(root, attribute, joinType);
+        return join == null ? createJoin(root, attribute, joinType) : join;
+    }
+
+    private static <X, Z> Join<X, ?> createJoin(final From<Z, X> root, final String attribute, final JoinType joinType) {
+        return joinType == null ? root.join(attribute) : root.join(attribute, joinType);
+    }
+
+    private static <X, Z> Join<X, ?> getJoin(
+            final From<Z, X> root, final String attribute, final JoinType joinType) {
+        final Join<X, ?> fetchJoin = getJoinFromFetches(root, attribute, joinType);
+        if (fetchJoin != null) {
+            return fetchJoin;
+        }
+        return getJoinFromJoins(root, attribute, joinType);
+    }
+
+    private static <X, Z> Join<X, ?> getJoinFromFetches(
+            final From<Z, X> root, final String attribute, final JoinType joinType) {
+        for (final Fetch<X, ?> fetch : root.getFetches()) {
+            if (Join.class.isAssignableFrom(fetch.getClass()) &&
+                    fetch.getAttribute().getName().equals(attribute) &&
+                    (joinType == null || fetch.getJoinType().equals(joinType))) {
+                return (Join<X, ?>) fetch;
+            }
+        }
+        return null;
+    }
+
+    private static <X, Z> Join<X, ?> getJoinFromJoins(
+            final From<Z, X> root, final String attribute, final JoinType joinType) {
+        for (final Join<X, ?> join : root.getJoins()) {
+            if (join.getAttribute().getName().equals(attribute) &&
+                    (joinType == null || join.getJoinType().equals(joinType))) {
+                return join;
+            }
+        }
+        return null;
+    }
+}

--- a/rsql-jpa/src/main/java/io/github/perplexhub/rsql/RSQLJPAPredicateConverter.java
+++ b/rsql-jpa/src/main/java/io/github/perplexhub/rsql/RSQLJPAPredicateConverter.java
@@ -99,7 +99,7 @@ public class RSQLJPAPredicateConverter extends RSQLVisitorBase<Predicate, From> 
 						previousClassMetadata = classMetadata;
 						classMetadata = getManagedType(associationType);
 
-						String keyJoin = root.getJavaType().getSimpleName().concat(".").concat(mappedProperty);
+						String keyJoin = getKeyJoin(root, mappedProperty);
 						if (isOneToAssociationType) {
 							if (joinHints.containsKey(keyJoin)) {
 								log.debug("Create a join between [{}] and [{}] using key [{}] with supplied hints", previousClass, classMetadata.getJavaType().getName(), keyJoin);
@@ -130,7 +130,7 @@ public class RSQLJPAPredicateConverter extends RSQLVisitorBase<Predicate, From> 
 						String previousClass = classMetadata.getJavaType().getName();
 						attribute = classMetadata.getAttribute(property);
 						classMetadata = getManagedElementCollectionType(mappedProperty, classMetadata);
-						String keyJoin = root.getJavaType().getSimpleName().concat(".").concat(mappedProperty);
+						String keyJoin = getKeyJoin(root, mappedProperty);
 						log.debug("Create a element collection join between [{}] and [{}] using key [{}]", previousClass, classMetadata.getJavaType().getName(), keyJoin);
 						root = join(keyJoin, root, mappedProperty);
 					} else {

--- a/rsql-jpa/src/main/java/io/github/perplexhub/rsql/RSQLJPAPredicateConverter.java
+++ b/rsql-jpa/src/main/java/io/github/perplexhub/rsql/RSQLJPAPredicateConverter.java
@@ -170,11 +170,7 @@ public class RSQLJPAPredicateConverter extends RSQLVisitorBase<Predicate, From> 
 		if (cachedJoins.containsKey(keyJoin)) {
 			root = cachedJoins.get(keyJoin);
 		} else {
-			if (joinType == null) {
-				root = ((From) root).join(mappedProperty);
-			} else {
-				root = ((From) root).join(mappedProperty, joinType);
-			}
+			root = JoinUtils.getOrCreateJoin((From) root, mappedProperty, joinType);
 			cachedJoins.put(keyJoin, root);
 		}
 		return root;

--- a/rsql-jpa/src/test/java/io/github/perplexhub/rsql/JoinUtilsTest.java
+++ b/rsql-jpa/src/test/java/io/github/perplexhub/rsql/JoinUtilsTest.java
@@ -1,0 +1,132 @@
+package io.github.perplexhub.rsql;
+
+import org.hibernate.query.criteria.internal.path.SingularAttributeJoin;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import javax.persistence.criteria.Fetch;
+import javax.persistence.criteria.From;
+import javax.persistence.criteria.Join;
+import javax.persistence.criteria.JoinType;
+import javax.persistence.metamodel.Attribute;
+import javax.persistence.metamodel.SingularAttribute;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class JoinUtilsTest {
+
+    private static final String ATTRIBUTE = "attribute";
+
+    @Mock
+    private From<?, ?> root;
+
+    @Test
+    public void testGetOrCreateJoinCreatesJoinWhenNeitherFetchNorJoinExists() {
+        final Join<Object, Object> join = mock(Join.class);
+        when(root.join(anyString())).thenReturn(join);
+
+        final Join<?, ?> result = JoinUtils.getOrCreateJoin(root, ATTRIBUTE, null);
+
+        assertEquals(join, result);
+
+        verify(root).join(ATTRIBUTE);
+    }
+
+    @Test
+    public void testGetOrCreateJoinCreatesJoinWithTypeWhenNeitherFetchNorJoinExists() {
+        final Join<Object, Object> join = mock(Join.class);
+        when(root.join(anyString(), any(JoinType.class))).thenReturn(join);
+
+        final Join<?, ?> result = JoinUtils.getOrCreateJoin(root, ATTRIBUTE, JoinType.LEFT);
+
+        assertEquals(join, result);
+
+        verify(root).join(ATTRIBUTE, JoinType.LEFT);
+    }
+
+    @Test
+    public void testGetOrCreateJoinReturnsJoinWhenFetchExists() {
+        final Attribute<?, ?> attribute = mock(SingularAttribute.class);
+        when(attribute.getName()).thenReturn(ATTRIBUTE);
+
+        final Fetch<?, ?> fetch = mock(SingularAttributeJoin.class);
+        doReturn(attribute).when(fetch).getAttribute();
+
+        doReturn(Collections.singleton(fetch)).when(root).getFetches();
+
+        final Join<?, ?> result = JoinUtils.getOrCreateJoin(root, ATTRIBUTE, null);
+
+        assertEquals(fetch, result);
+
+        verify(root, never()).join(anyString());
+        verify(root, never()).join(anyString(), any(JoinType.class));
+    }
+
+    @Test
+    public void testGetOrCreateJoinReturnsJoinOfTypeWhenFetchExists() {
+        final Attribute<?, ?> attribute = mock(SingularAttribute.class);
+        when(attribute.getName()).thenReturn(ATTRIBUTE);
+
+        final Fetch<?, ?> fetch = mock(SingularAttributeJoin.class);
+        doReturn(attribute).when(fetch).getAttribute();
+        when(fetch.getJoinType()).thenReturn(JoinType.RIGHT);
+
+        doReturn(Collections.singleton(fetch)).when(root).getFetches();
+
+        final Join<?, ?> result = JoinUtils.getOrCreateJoin(root, ATTRIBUTE, JoinType.RIGHT);
+
+        assertEquals(fetch, result);
+
+        verify(root, never()).join(anyString());
+        verify(root, never()).join(anyString(), any(JoinType.class));
+    }
+
+    @Test
+    public void testGetOrCreateJoinReturnsJoinWhenJoinExists() {
+        final Attribute<?, ?> attribute = mock(SingularAttribute.class);
+        when(attribute.getName()).thenReturn(ATTRIBUTE);
+
+        final Join<?, ?> join = mock(SingularAttributeJoin.class);
+        doReturn(attribute).when(join).getAttribute();
+
+        doReturn(Collections.singleton(join)).when(root).getJoins();
+
+        final Join<?, ?> result = JoinUtils.getOrCreateJoin(root, ATTRIBUTE, null);
+
+        assertEquals(join, result);
+
+        verify(root, never()).join(anyString());
+        verify(root, never()).join(anyString(), any(JoinType.class));
+    }
+
+    @Test
+    public void testGetOrCreateJoinReturnsJoinOfTypeWhenJoinExists() {
+        final Attribute<?, ?> attribute = mock(SingularAttribute.class);
+        when(attribute.getName()).thenReturn(ATTRIBUTE);
+
+        final Join<?, ?> join = mock(SingularAttributeJoin.class);
+        doReturn(attribute).when(join).getAttribute();
+        when(join.getJoinType()).thenReturn(JoinType.LEFT);
+
+        doReturn(Collections.singleton(join)).when(root).getJoins();
+
+        final Join<?, ?> result = JoinUtils.getOrCreateJoin(root, ATTRIBUTE, JoinType.LEFT);
+
+        assertEquals(join, result);
+
+        verify(root, never()).join(anyString());
+        verify(root, never()).join(anyString(), any(JoinType.class));
+    }
+}

--- a/rsql-jpa/src/test/java/io/github/perplexhub/rsql/RSQLJPASupportTest.java
+++ b/rsql-jpa/src/test/java/io/github/perplexhub/rsql/RSQLJPASupportTest.java
@@ -12,7 +12,9 @@ import java.util.*;
 
 import javax.persistence.criteria.Expression;
 import javax.persistence.criteria.JoinType;
+import javax.persistence.criteria.Predicate;
 
+import io.github.perplexhub.rsql.model.Status;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.groups.Tuple;
 import org.junit.Before;
@@ -1008,6 +1010,37 @@ public class RSQLJPASupportTest {
 				.extracting(User::getId)
 				.doesNotContain(user2.getId())
 				.contains(user1.getId());
+	}
+
+	@Test
+	@Transactional
+	public void testFetch() {
+		Specification<User> spec = RSQLJPASupport.<User>toSpecification("company.name=ilike='inc'", true)
+				.and(toSort("city.name,asc;company.name,asc;name,asc"));
+
+		List<User> result = userRepository.findAll((root, query, builder) -> {
+			/*
+                 Join fetch should be applied only for query to fetch the "data", not for "count" query to do pagination.
+                 Handled this by checking the criteriaQuery.getResultType(), if it's long that means query is
+                 for count so not appending join fetch else append it.
+              */
+			if (Long.class != query.getResultType()) {
+				root.fetch("company", JoinType.INNER);
+				root.fetch("city", JoinType.LEFT);
+				root.fetch("userRoles", JoinType.LEFT);
+			}
+
+			Predicate rsqlPredicate = spec.toPredicate(root, query, builder);
+
+			Predicate extraPredicate = builder.equal(root.get("status"), Status.ACTIVE);
+
+			return builder.and(rsqlPredicate, extraPredicate);
+		});
+
+		assertEquals(1, result.size());
+		Assertions.assertThat(result)
+				.extracting(User::getId)
+				.containsExactly(6);
 	}
 
 	@Before


### PR DESCRIPTION
Changes to better reuse joins. This helps when needing to fetch child entities from the root in the same query. 