### PR TITLE
Join reuse improvements to help with JPA fetches (#102)

### DIFF
--- a/rsql-jpa/src/main/java/io/github/perplexhub/rsql/JoinUtils.java
+++ b/rsql-jpa/src/main/java/io/github/perplexhub/rsql/JoinUtils.java
@@ -1,0 +1,54 @@
+package io.github.perplexhub.rsql;
+
+import jakarta.persistence.criteria.Fetch;
+import jakarta.persistence.criteria.From;
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.JoinType;
+
+final class JoinUtils {
+
+    private JoinUtils() {
+    }
+
+    public static <X, Z> Join<X, ?> getOrCreateJoin(
+            final From<Z, X> root, final String attribute, final JoinType joinType) {
+        final Join<X, ?> join = getJoin(root, attribute, joinType);
+        return join == null ? createJoin(root, attribute, joinType) : join;
+    }
+
+    private static <X, Z> Join<X, ?> createJoin(final From<Z, X> root, final String attribute, final JoinType joinType) {
+        return joinType == null ? root.join(attribute) : root.join(attribute, joinType);
+    }
+
+    private static <X, Z> Join<X, ?> getJoin(
+            final From<Z, X> root, final String attribute, final JoinType joinType) {
+        final Join<X, ?> fetchJoin = getJoinFromFetches(root, attribute, joinType);
+        if (fetchJoin != null) {
+            return fetchJoin;
+        }
+        return getJoinFromJoins(root, attribute, joinType);
+    }
+
+    private static <X, Z> Join<X, ?> getJoinFromFetches(
+            final From<Z, X> root, final String attribute, final JoinType joinType) {
+        for (final Fetch<X, ?> fetch : root.getFetches()) {
+            if (Join.class.isAssignableFrom(fetch.getClass()) &&
+                    fetch.getAttribute().getName().equals(attribute) &&
+                    (joinType == null || fetch.getJoinType().equals(joinType))) {
+                return (Join<X, ?>) fetch;
+            }
+        }
+        return null;
+    }
+
+    private static <X, Z> Join<X, ?> getJoinFromJoins(
+            final From<Z, X> root, final String attribute, final JoinType joinType) {
+        for (final Join<X, ?> join : root.getJoins()) {
+            if (join.getAttribute().getName().equals(attribute) &&
+                    (joinType == null || join.getJoinType().equals(joinType))) {
+                return join;
+            }
+        }
+        return null;
+    }
+}

--- a/rsql-jpa/src/main/java/io/github/perplexhub/rsql/RSQLJPAPredicateConverter.java
+++ b/rsql-jpa/src/main/java/io/github/perplexhub/rsql/RSQLJPAPredicateConverter.java
@@ -99,7 +99,7 @@ public class RSQLJPAPredicateConverter extends RSQLVisitorBase<Predicate, From> 
 						previousClassMetadata = classMetadata;
 						classMetadata = getManagedType(associationType);
 
-						String keyJoin = root.getJavaType().getSimpleName().concat(".").concat(mappedProperty);
+						String keyJoin = getKeyJoin(root, mappedProperty);
 						if (isOneToAssociationType) {
 							if (joinHints.containsKey(keyJoin)) {
 								log.debug("Create a join between [{}] and [{}] using key [{}] with supplied hints", previousClass, classMetadata.getJavaType().getName(), keyJoin);
@@ -130,7 +130,7 @@ public class RSQLJPAPredicateConverter extends RSQLVisitorBase<Predicate, From> 
 						String previousClass = classMetadata.getJavaType().getName();
 						attribute = classMetadata.getAttribute(property);
 						classMetadata = getManagedElementCollectionType(mappedProperty, classMetadata);
-						String keyJoin = root.getJavaType().getSimpleName().concat(".").concat(mappedProperty);
+						String keyJoin = getKeyJoin(root, mappedProperty);
 						log.debug("Create a element collection join between [{}] and [{}] using key [{}]", previousClass, classMetadata.getJavaType().getName(), keyJoin);
 						root = join(keyJoin, root, mappedProperty);
 					} else {
@@ -170,11 +170,7 @@ public class RSQLJPAPredicateConverter extends RSQLVisitorBase<Predicate, From> 
 		if (cachedJoins.containsKey(keyJoin)) {
 			root = cachedJoins.get(keyJoin);
 		} else {
-			if (joinType == null) {
-				root = ((From) root).join(mappedProperty);
-			} else {
-				root = ((From) root).join(mappedProperty, joinType);
-			}
+			root = JoinUtils.getOrCreateJoin((From) root, mappedProperty, joinType);
 			cachedJoins.put(keyJoin, root);
 		}
 		return root;

--- a/rsql-jpa/src/test/java/io/github/perplexhub/rsql/JoinUtilsTest.java
+++ b/rsql-jpa/src/test/java/io/github/perplexhub/rsql/JoinUtilsTest.java
@@ -1,0 +1,132 @@
+package io.github.perplexhub.rsql;
+
+import jakarta.persistence.criteria.Fetch;
+import jakarta.persistence.criteria.From;
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.JoinType;
+import jakarta.persistence.metamodel.Attribute;
+import org.hibernate.metamodel.model.domain.SingularPersistentAttribute;
+import org.hibernate.query.sqm.tree.domain.SqmSingularJoin;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class JoinUtilsTest {
+
+    private static final String ATTRIBUTE = "attribute";
+
+    @Mock
+    private From<?, ?> root;
+
+    @Test
+    void testGetOrCreateJoinCreatesJoinWhenNeitherFetchNorJoinExists() {
+        final Join<Object, Object> join = mock(Join.class);
+        when(root.join(anyString())).thenReturn(join);
+
+        final Join<?, ?> result = JoinUtils.getOrCreateJoin(root, ATTRIBUTE, null);
+
+        assertEquals(join, result);
+
+        verify(root).join(ATTRIBUTE);
+    }
+
+    @Test
+    void testGetOrCreateJoinCreatesJoinWithTypeWhenNeitherFetchNorJoinExists() {
+        final Join<Object, Object> join = mock(Join.class);
+        when(root.join(anyString(), any(JoinType.class))).thenReturn(join);
+
+        final Join<?, ?> result = JoinUtils.getOrCreateJoin(root, ATTRIBUTE, JoinType.LEFT);
+
+        assertEquals(join, result);
+
+        verify(root).join(ATTRIBUTE, JoinType.LEFT);
+    }
+
+    @Test
+    void testGetOrCreateJoinReturnsJoinWhenFetchExists() {
+        final Attribute<?, ?> attribute = mock(SingularPersistentAttribute.class);
+        when(attribute.getName()).thenReturn(ATTRIBUTE);
+
+        final Fetch<?, ?> fetch = mock(SqmSingularJoin.class);
+        doReturn(attribute).when(fetch).getAttribute();
+
+        doReturn(Collections.singleton(fetch)).when(root).getFetches();
+
+        final Join<?, ?> result = JoinUtils.getOrCreateJoin(root, ATTRIBUTE, null);
+
+        assertEquals(fetch, result);
+
+        verify(root, never()).join(anyString());
+        verify(root, never()).join(anyString(), any(JoinType.class));
+    }
+
+    @Test
+    void testGetOrCreateJoinReturnsJoinOfTypeWhenFetchExists() {
+        final Attribute<?, ?> attribute = mock(SingularPersistentAttribute.class);
+        when(attribute.getName()).thenReturn(ATTRIBUTE);
+
+        final Fetch<?, ?> fetch = mock(SqmSingularJoin.class);
+        doReturn(attribute).when(fetch).getAttribute();
+        when(fetch.getJoinType()).thenReturn(JoinType.RIGHT);
+
+        doReturn(Collections.singleton(fetch)).when(root).getFetches();
+
+        final Join<?, ?> result = JoinUtils.getOrCreateJoin(root, ATTRIBUTE, JoinType.RIGHT);
+
+        assertEquals(fetch, result);
+
+        verify(root, never()).join(anyString());
+        verify(root, never()).join(anyString(), any(JoinType.class));
+    }
+
+    @Test
+    void testGetOrCreateJoinReturnsJoinWhenJoinExists() {
+        final Attribute<?, ?> attribute = mock(Attribute.class);
+        when(attribute.getName()).thenReturn(ATTRIBUTE);
+
+        final Join<?, ?> join = mock(Join.class);
+        doReturn(attribute).when(join).getAttribute();
+
+        doReturn(Collections.singleton(join)).when(root).getJoins();
+
+        final Join<?, ?> result = JoinUtils.getOrCreateJoin(root, ATTRIBUTE, null);
+
+        assertEquals(join, result);
+
+        verify(root, never()).join(anyString());
+        verify(root, never()).join(anyString(), any(JoinType.class));
+    }
+
+    @Test
+    void testGetOrCreateJoinReturnsJoinOfTypeWhenJoinExists() {
+        final Attribute<?, ?> attribute = mock(Attribute.class);
+        when(attribute.getName()).thenReturn(ATTRIBUTE);
+
+        final Join<?, ?> join = mock(Join.class);
+        doReturn(attribute).when(join).getAttribute();
+        when(join.getJoinType()).thenReturn(JoinType.LEFT);
+
+        doReturn(Collections.singleton(join)).when(root).getJoins();
+
+        final Join<?, ?> result = JoinUtils.getOrCreateJoin(root, ATTRIBUTE, JoinType.LEFT);
+
+        assertEquals(join, result);
+
+        verify(root, never()).join(anyString());
+        verify(root, never()).join(anyString(), any(JoinType.class));
+    }
+}


### PR DESCRIPTION
* Refactoring to use `getKeyJoin` method

* Adding JoinUtils class

* Updating RSQLJPAPredicateConverter to use JoinUtils.getOrCreateJoin to reuse joins