### PR TITLE
Remove redundant subtypes searching when entity is abstract class.

### DIFF
--- a/rsql-common/pom.xml
+++ b/rsql-common/pom.xml
@@ -10,11 +10,6 @@
 	<name>io.github.perplexhub - RSQL-Common</name>
 	<dependencies>
 		<dependency>
-			<groupId>org.reflections</groupId>
-			<artifactId>reflections</artifactId>
-			<version>0.10.2</version>
-		</dependency>
-		<dependency>
 			<groupId>io.github.nstdio</groupId>
 			<artifactId>rsql-parser</artifactId>
 		</dependency>


### PR DESCRIPTION
The code introduced in #44 is no longer executed because starting from Hibernate 6 the framework itself finds attribute in subtypes. Also, the consequence of the change we no longer need the `org.reflections:reflections` dependency, which was used solely for purpose of finding a subtypes of a given type.