### PR TITLE
Jsonpath predicate

### DIFF
--- a/rsql-common/src/main/java/io/github/perplexhub/rsql/RSQLCustomPredicateInput.java
+++ b/rsql-common/src/main/java/io/github/perplexhub/rsql/RSQLCustomPredicateInput.java
@@ -2,6 +2,7 @@ package io.github.perplexhub.rsql;
 
 import java.util.List;
 
+import cz.jirutka.rsql.parser.ast.ComparisonNode;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.From;
 import jakarta.persistence.criteria.Path;
@@ -15,16 +16,18 @@ public class RSQLCustomPredicateInput {
     CriteriaBuilder criteriaBuilder;
     Path<?> path;
     Attribute<?, ?> attribute;
+    String attributeName;
     List<Object> arguments;
     From<?, ?> root;
 
     public static RSQLCustomPredicateInput of(
             CriteriaBuilder criteriaBuilder,
             Path<?> path,
+            String attributeName,
             List<Object> arguments,
             From<?, ?> root
     ) {
-        return of(criteriaBuilder, path, null, arguments, root);
+        return of(criteriaBuilder, path, null, attributeName, arguments, root);
     }
 
 }

--- a/rsql-common/src/main/java/io/github/perplexhub/rsql/RSQLVisitorBase.java
+++ b/rsql-common/src/main/java/io/github/perplexhub/rsql/RSQLVisitorBase.java
@@ -29,7 +29,7 @@ public abstract class RSQLVisitorBase<R, A> implements RSQLVisitor<R, A> {
 
 	protected static volatile @Setter Map<Class, ManagedType> managedTypeMap;
 	protected static volatile @Setter Map<String, EntityManager> entityManagerMap;
-	protected static volatile @Setter @Getter Map<EntityManager, Database> entityManagerDatabase = Map.of();
+	protected static volatile @Setter @Getter Map<EntityManager, Database> entityManagerDatabase = java.util.Map.of();
 	protected static final Map<Class, Class> primitiveToWrapper;
 	protected static volatile @Setter Map<Class<?>, Map<String, String>> propertyRemapping;
 	protected static volatile @Setter Map<Class<?>, List<String>> globalPropertyWhitelist;
@@ -44,7 +44,7 @@ public abstract class RSQLVisitorBase<R, A> implements RSQLVisitor<R, A> {
 		return managedTypeMap != null ? managedTypeMap : Collections.emptyMap();
 	}
 
-	protected Map<String, EntityManager> getEntityManagerMap() {
+	protected static Map<String, EntityManager> getEntityManagerMap() {
 		return entityManagerMap != null ? entityManagerMap : Collections.emptyMap();
 	}
 

--- a/rsql-jpa/src/main/java/io/github/perplexhub/rsql/RSQLJPAPredicateConverter.java
+++ b/rsql-jpa/src/main/java/io/github/perplexhub/rsql/RSQLJPAPredicateConverter.java
@@ -151,15 +151,15 @@ public class RSQLJPAPredicateConverter extends RSQLVisitorBase<Predicate, From> 
 
 	private boolean isJsonType(String mappedProperty, ManagedType<?> classMetadata) {
 		return Optional.ofNullable(classMetadata.getAttribute(mappedProperty))
-				.map(this::isJsonType)
+				.map(RSQLJPAPredicateConverter::isJsonType)
 				.orElse(false);
 	}
 	
-	private boolean isJsonType(Attribute<?, ?> attribute) {
-    return isJsonColumn(attribute) && getDatabase(attribute).map(JSON_SUPPORT::contains).orElse(false);
+	public static boolean isJsonType(Attribute<?, ?> attribute) {
+    	return isJsonColumn(attribute) && getDatabase(attribute).map(JSON_SUPPORT::contains).orElse(false);
 	}
 
-	private boolean isJsonColumn(Attribute<?, ?> attribute) {
+	private static boolean isJsonColumn(Attribute<?, ?> attribute) {
 		return Optional.ofNullable(attribute)
 				.filter(attr -> attr.getJavaMember() instanceof Field)
 				.map(attr -> ((Field) attr.getJavaMember()))
@@ -169,7 +169,7 @@ public class RSQLJPAPredicateConverter extends RSQLVisitorBase<Predicate, From> 
 				.orElse(false);
 	}
 
-	private Optional<Database> getDatabase(Attribute<?, ?> attribute) {
+	private static Optional<Database> getDatabase(Attribute<?, ?> attribute) {
 		return getEntityManagerMap()
 				.values()
 				.stream()
@@ -213,7 +213,7 @@ public class RSQLJPAPredicateConverter extends RSQLVisitorBase<Predicate, From> 
 			for (String argument : node.getArguments()) {
 				arguments.add(convert(argument, customPredicate.getType()));
 			}
-			return customPredicate.getConverter().apply(RSQLCustomPredicateInput.of(builder, attrPath, attribute, arguments, root));
+			return customPredicate.getConverter().apply(RSQLCustomPredicateInput.of(builder, attrPath, attribute, node.getSelector(), arguments, root));
 		}
 
 		final boolean json = isJsonType(attribute);

--- a/rsql-jpa/src/main/java/io/github/perplexhub/rsql/jsonb/JsonbExpressionBuilder.java
+++ b/rsql-jpa/src/main/java/io/github/perplexhub/rsql/jsonb/JsonbExpressionBuilder.java
@@ -1,0 +1,213 @@
+package io.github.perplexhub.rsql.jsonb;
+
+import cz.jirutka.rsql.parser.ast.ComparisonOperator;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static io.github.perplexhub.rsql.RSQLOperators.*;
+import static io.github.perplexhub.rsql.jsonb.JsonbExpressionUtils.*;
+
+public class JsonbExpressionBuilder {
+    protected static boolean dateTimeSupport = true;
+
+    private final ComparisonOperator operator;
+    private final String keyPath;
+    private final List<ArgValue> values;
+
+    public JsonbExpressionBuilder(ComparisonOperator operator, String keyPath, List<String> args) {
+
+        //Sanity check
+        this.operator = Objects.requireNonNull(operator);
+        this.keyPath = Objects.requireNonNull(keyPath);
+
+        if(FORBIDDEN_NEGATION.contains(operator)) {
+            throw new IllegalArgumentException("Operator " + operator + " cannot be negated");
+        }
+
+        var candidateValues = removeEmptyValuesIfNullCheck(operator, args);
+
+        //List must have at least one value except for IS_NULL and NOT_NULL
+        if(candidateValues.isEmpty() && !REQUIRE_NO_ARGUMENTS.contains(operator)) {
+            throw new IllegalArgumentException("Values must not be empty");
+        }
+
+        //Requires two values
+        if(REQUIRE_TWO_ARGUMENTS.contains(operator) && candidateValues.size() != 2) {
+            throw new IllegalArgumentException("Operator " + operator + " requires two values");
+        }
+
+        //Operators other than IS_NULL, NOT_NULL, BETWEEN, NOT_BETWEEN, IN, NOT_IN require exactly one value
+        if(REQUIRE_ONE_ARGUMENT.contains(operator) && candidateValues.size() != 1) {
+            throw new IllegalArgumentException("Operator " + operator + " requires one value");
+        }
+
+        //Operators IN and NOT_IN require at least one value
+        if(REQUIRE_AT_LEAST_ONE_ARGUMENT.contains(operator) && candidateValues.isEmpty()) {
+            throw new IllegalArgumentException("Operator " + operator + " requires at least one value");
+        }
+        //Copy to unmodifiable list
+        this.values = findMoreTypes(operator, candidateValues);
+    }
+
+    /**
+     * Builds a json path expression for a given keyPath and operator.
+     * @return the json path expression
+     */
+    String getJsonPathExpression() {
+        List<String> valuesToCompare = values.stream().map(argValue -> argValue.print(operator)).toList();
+
+        String targetPath = String.format("$.%s", removeJsonbReferenceFromKeyPath(keyPath));
+        String valueReference = values.stream().filter(argValue -> argValue.baseJsonType().equals(BaseJsonType.DATE_TIME))
+                .findFirst()
+                .map(v -> "@.datetime()")
+                .orElse("@");
+        ComparisonOperator realOperator = transformEqualsToLike(operator, valuesToCompare);
+        String comparisonTemplate = operatorToTemplate(realOperator, valuesToCompare.size());
+        List<String> templateArguments = new ArrayList<>();
+        templateArguments.add(valueReference);
+        templateArguments.addAll(valuesToCompare);
+        return String.format("%s ? %s", targetPath, String.format(comparisonTemplate, templateArguments.toArray()));
+    }
+
+    /**
+     * If the operator is NOT_NULL, we will remove all values.
+     */
+    private List<String> removeEmptyValuesIfNullCheck(ComparisonOperator operator, List<String> args) {
+        if(operator.equals(NOT_NULL)) {
+            return Collections.emptyList();
+        }
+        return args;
+    }
+
+    /**
+     * Try to find a more specific type for the given values.
+     * We will keep the original value if we cannot find a more specific type for all values.
+     */
+    private List<ArgValue> findMoreTypes(ComparisonOperator operator, List<String> values) {
+        if(NOT_RELEVANT_FOR_CONVERSION.contains(operator)) {
+            return values.stream().map(s -> new ArgValue(s, BaseJsonType.STRING)).toList();
+        }
+        List<JsonbExpressionUtils.ArgConverter> argConverters = dateTimeSupport ?
+                List.of(DATE_TIME_CONVERTER, NUMBER_CONVERTER, BOOLEAN_ARG_CONVERTER)
+                : List.of(NUMBER_CONVERTER, BOOLEAN_ARG_CONVERTER);
+        Optional<ArgConverter> candidateConverter = argConverters.stream()
+                .filter(argConverter -> values.stream().allMatch(argConverter::accepts))
+                .findFirst();
+        return candidateConverter.map(argConverter -> values.stream()
+                        .map(argConverter::convert).toList())
+                .orElseGet(() -> values.stream().map(s -> new ArgValue(s, BaseJsonType.STRING)).toList());
+    }
+
+    /**
+     * If the operator is EQUAL and one of the values contains a wildcard, we will transform the operator to LIKE.
+     */
+    private ComparisonOperator transformEqualsToLike(ComparisonOperator operator, List<String> valuesToCompare) {
+        boolean hasWildcard = valuesToCompare.stream().anyMatch(s -> s.contains("*"));
+        if(!hasWildcard) {
+            return operator;
+        }
+        if(operator.equals(EQUAL)) {
+            return LIKE;
+        }
+        return operator;
+    }
+
+    /**
+     * Removes the jsonb reference from the keyPath.
+     * @param keyPath the keyPath
+     * @return the keyPath without the jsonb reference
+     */
+    String removeJsonbReferenceFromKeyPath(String keyPath) {
+        List<String> keyPathParts = Arrays.asList(keyPath.split("\\."));
+        //If the keyPath is empty, we will return an empty string
+        if(keyPathParts.isEmpty()) {
+            return "";
+        }
+        //Forget the first part as it represents the jsonb column name
+        keyPathParts = keyPathParts.subList(1, keyPathParts.size());
+        return String.join(".", keyPathParts);
+    }
+
+    /**
+     * Returns the template for the given operator.
+     * @param operator the operator
+     * @param numberOfArguments the number of arguments
+     * @return the template
+     */
+    String operatorToTemplate(ComparisonOperator operator, int numberOfArguments) {
+        if(operator.equals(NOT_NULL)) {
+            if(numberOfArguments != 0) {
+                throw new IllegalArgumentException("Null operator requires no value");
+            }
+            return "(%s != null)";
+        }
+        if(operator.equals(EQUAL)) {
+            if(numberOfArguments != 1) {
+                throw new IllegalArgumentException("Equal operator requires exactly one value");
+            }
+            return "(%s == %s)";
+        }
+        if (operator.equals(GREATER_THAN)) {
+            if(numberOfArguments != 1) {
+                throw new IllegalArgumentException("Greater than operator requires exactly one value");
+            }
+            return "(%s > %s)";
+        }
+        if (operator.equals(GREATER_THAN_OR_EQUAL)) {
+            if(numberOfArguments != 1) {
+                throw new IllegalArgumentException("Greater than or equal operator requires exactly one value");
+            }
+            return "(%s >= %s)";
+        }
+        if (operator.equals(LESS_THAN)) {
+            if(numberOfArguments != 1) {
+                throw new IllegalArgumentException("Less than operator requires exactly one value");
+            }
+            return "(%s < %s)";
+        }
+        if (operator.equals(LESS_THAN_OR_EQUAL)) {
+            if(numberOfArguments != 1) {
+                throw new IllegalArgumentException("Less than or equal operator requires exactly one value");
+            }
+            return "(%s <= %s)";
+        }
+        if (operator.equals(LIKE)) {
+            if(numberOfArguments != 1) {
+                throw new IllegalArgumentException("Like operator requires exactly one value");
+            }
+            return "(%s like_regex %s)";
+        }
+        if (operator.equals(IGNORE_CASE)) {
+            if(numberOfArguments != 1) {
+                throw new IllegalArgumentException("Ignore case operator requires exactly one value");
+            }
+            return "(%s like_regex %s flag \"i\")";
+        }
+        if (operator.equals(IGNORE_CASE_LIKE)) {
+            if(numberOfArguments != 1) {
+                throw new IllegalArgumentException("Ignore case like operator requires exactly one value");
+            }
+            return "(%s like_regex %s flag \"i\")";
+        }
+        if (operator.equals(BETWEEN)) {
+            if(numberOfArguments != 2) {
+                throw new IllegalArgumentException("Between operator requires exactly two values");
+            }
+            return "(%1$s >= %2$s && %1$s <= %3$s)";
+        }
+        if (operator.equals(IN)) {
+            if(numberOfArguments < 1) {
+                throw new IllegalArgumentException("In operator requires at least one value");
+            }
+            var orChain = new ArrayList<String>();
+            for (int i = 1; i <= numberOfArguments; i++) {
+                orChain.add("%1$s == %" + (i + 1) + "$s");
+            }
+            return orChain.stream()
+                    .collect(Collectors.joining(" || ", "(", ")"));
+        }
+        throw new UnsupportedOperationException("Operation " + operator + " is not supported yet");
+
+    }
+}

--- a/rsql-jpa/src/main/java/io/github/perplexhub/rsql/jsonb/JsonbExpressionUtils.java
+++ b/rsql-jpa/src/main/java/io/github/perplexhub/rsql/jsonb/JsonbExpressionUtils.java
@@ -1,0 +1,132 @@
+package io.github.perplexhub.rsql.jsonb;
+
+import cz.jirutka.rsql.parser.ast.ComparisonOperator;
+
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import static io.github.perplexhub.rsql.RSQLOperators.*;
+
+public class JsonbExpressionUtils {    /**
+ * The base json type.
+ */
+    enum BaseJsonType {
+        STRING, NUMBER, BOOLEAN, NULL, DATE_TIME, DATE_TIME_TZ
+    }
+
+    /**
+     * The argument value that holds the value and the base json type.
+     */
+    record ArgValue(String value, BaseJsonType baseJsonType) {
+        public String print(ComparisonOperator operator) {
+            return switch (baseJsonType) {
+                case STRING -> String.format("\"%s\"", printString(operator));
+                case NUMBER, BOOLEAN -> value;
+                case NULL -> "null";
+                case DATE_TIME, DATE_TIME_TZ -> String.format("\"%s\".datetime()", value);
+            };
+        }
+
+        public String printString(ComparisonOperator operator) {
+            String value = this.value;
+            if((operator.equals(LIKE)
+                    || operator.equals(NOT_LIKE)
+                    || operator.equals(IGNORE_CASE_LIKE)
+                    || operator.equals(IGNORE_CASE_NOT_LIKE))
+                    && !value.contains("*")
+            ) {
+                return String.format(".*%s.*", value);
+            }
+            return value.replaceAll(WILD_CARD_PATTERN.pattern(), ".*");
+        }
+    }
+
+    /**
+     * Interface for argument converters.
+     */
+    interface ArgConverter {
+        boolean accepts(String s);
+        ArgValue convert(String s);
+    }
+
+    static ArgConverter DATE_TIME_CONVERTER = new ArgConverter() {
+        @Override
+        public boolean accepts(String s) {
+            return ISO_DATE_TIME_PATTERN_TZ.matcher(s).matches()
+                    || ISO_DATE_TIME_PATTERN.matcher(s).matches()
+                    || ISO_DATE_PATTERN.matcher(s).matches()
+                    || ISO_TIME_PATTERN_TZ.matcher(s).matches()
+                    || ISO_TIME_PATTERN.matcher(s).matches();
+        }
+
+        @Override
+        public ArgValue convert(String s) {
+            return new ArgValue(s, BaseJsonType.DATE_TIME);
+        }
+    };
+
+    static ArgConverter NUMBER_CONVERTER = new ArgConverter() {
+
+        @Override
+        public boolean accepts(String s) {
+            return NUMBER_PATTERN.matcher(s).matches()
+                    || INTEGER_PATTERN.matcher(s).matches();
+        }
+
+
+        @Override
+        public ArgValue convert(String s) {
+            return new ArgValue(s, BaseJsonType.NUMBER);
+        }
+    };
+
+
+    static ArgConverter BOOLEAN_ARG_CONVERTER = new ArgConverter() {
+
+        @Override
+        public boolean accepts(String s) {
+            return BOOLEAN_PATTERN.matcher(s).matches();
+        }
+
+        @Override
+        public ArgValue convert(String s) {
+            return new ArgValue(s, BaseJsonType.BOOLEAN);
+        }
+    };
+
+    private static final Pattern ISO_DATE_TIME_PATTERN_TZ = Pattern.compile("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?(Z|[+-]\\d{2}:\\d{2})$");
+
+    private static final Pattern ISO_DATE_TIME_PATTERN = Pattern.compile("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?$");
+
+    private static final Pattern ISO_DATE_PATTERN = Pattern.compile("^\\d{4}-\\d{2}-\\d{2}$");
+
+    private static final Pattern ISO_TIME_PATTERN_TZ = Pattern.compile("^\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?(Z|[+-]\\d{2}:\\d{2})$");
+
+    private static final Pattern ISO_TIME_PATTERN = Pattern.compile("^\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?$");
+
+    private static final Pattern BOOLEAN_PATTERN = Pattern.compile("^(true|false)$");
+
+    private static final Pattern NUMBER_PATTERN = Pattern.compile("^\\d+\\.\\d+$");
+
+    private static final Pattern INTEGER_PATTERN = Pattern.compile("^\\d+$");
+
+    private static final Pattern WILD_CARD_PATTERN = Pattern.compile("\\*");
+
+    static final Set<ComparisonOperator> FORBIDDEN_NEGATION =
+            Set.of(IS_NULL, NOT_IN, NOT_LIKE, IGNORE_CASE_NOT_LIKE, NOT_BETWEEN);
+
+    static final Set<ComparisonOperator> NOT_RELEVANT_FOR_CONVERSION =
+            Set.of(NOT_NULL, LIKE, IGNORE_CASE);
+
+    static Set<ComparisonOperator> REQUIRE_NO_ARGUMENTS =
+            Set.of(NOT_NULL);
+
+    final static Set<ComparisonOperator> REQUIRE_ONE_ARGUMENT =
+            Set.of(EQUAL, GREATER_THAN, GREATER_THAN_OR_EQUAL, LESS_THAN, LESS_THAN_OR_EQUAL,
+                    LIKE, IGNORE_CASE, IGNORE_CASE_LIKE);
+
+    final static Set<ComparisonOperator> REQUIRE_TWO_ARGUMENTS = Set.of(BETWEEN);
+
+    final static Set<ComparisonOperator> REQUIRE_AT_LEAST_ONE_ARGUMENT = Set.of(IN);
+
+}

--- a/rsql-jpa/src/main/java/io/github/perplexhub/rsql/jsonb/JsonbPathSupport.java
+++ b/rsql-jpa/src/main/java/io/github/perplexhub/rsql/jsonb/JsonbPathSupport.java
@@ -1,0 +1,64 @@
+package io.github.perplexhub.rsql.jsonb;
+
+import cz.jirutka.rsql.parser.ast.ComparisonNode;
+import cz.jirutka.rsql.parser.ast.ComparisonOperator;
+import io.github.perplexhub.rsql.*;
+import jakarta.persistence.criteria.Predicate;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+public class JsonbPathSupport {
+
+    private static final String JSONB_PATH_EXISTS = "jsonb_path_exists";
+
+    private static final Map<ComparisonOperator, ComparisonOperator> NEGATE_OPERATORS =
+            Map.of(
+                    RSQLOperators.NOT_EQUAL, RSQLOperators.EQUAL,
+                    RSQLOperators.NOT_IN, RSQLOperators.IN,
+                    RSQLOperators.IS_NULL, RSQLOperators.NOT_NULL,
+                    RSQLOperators.NOT_LIKE, RSQLOperators.LIKE,
+                    RSQLOperators.IGNORE_CASE_NOT_LIKE, RSQLOperators.IGNORE_CASE_LIKE,
+                    RSQLOperators.NOT_BETWEEN, RSQLOperators.BETWEEN
+            );
+
+    private static final List<? extends RSQLCustomPredicate<String>> JSONB_CUSTOM_PREDICATES =
+            RSQLOperators.supportedOperators().stream()
+                    .map(JsonbPathSupport::jsonbPathExistsPredicate)
+                    .toList();
+
+    private static RSQLCustomPredicate<String> jsonbPathExistsPredicate(ComparisonOperator operator) {
+        Function<RSQLCustomPredicateInput, Predicate> custom = input -> {
+            var builder = input.getCriteriaBuilder();
+            var attrPath = input.getPath();
+            var arguments = input.getArguments().stream().map(Object::toString).toList();
+            if(RSQLJPAPredicateConverter.isJsonType(input.getAttribute())) {
+                var selector = input.getAttributeName();
+                var mayBeInvertedOperator = Optional.ofNullable(NEGATE_OPERATORS.get(operator));
+                var jsb = new JsonbExpressionBuilder(mayBeInvertedOperator.orElse(operator), selector, arguments);
+                var function = builder.function(JSONB_PATH_EXISTS, Boolean.class, attrPath, builder.literal(jsb.getJsonPathExpression()));
+                if (mayBeInvertedOperator.isPresent()) {
+                    return builder.isFalse(function);
+                } else {
+                    return builder.isTrue(function);
+                }
+            } else {
+                RSQLJPAPredicateConverter converter = new RSQLJPAPredicateConverter(builder, Map.of());
+                ComparisonNode node = new ComparisonNode(operator, input.getAttributeName(), arguments);
+                return converter.visit(node, input.getRoot());
+            }
+        };
+        return new RSQLCustomPredicate<>(operator, String.class, custom);
+    }
+
+    public static QuerySupport query(String rsqlKeyPath) {
+        return QuerySupport.builder()
+                .rsqlQuery(rsqlKeyPath)
+                .customPredicates(new ArrayList<>(JSONB_CUSTOM_PREDICATES))
+                .build();
+    }
+
+}

--- a/rsql-jpa/src/test/java/io/github/perplexhub/rsql/RSQLJPASupportPostgresJsonPathTest.java
+++ b/rsql-jpa/src/test/java/io/github/perplexhub/rsql/RSQLJPASupportPostgresJsonPathTest.java
@@ -1,0 +1,290 @@
+package io.github.perplexhub.rsql;
+
+import io.github.perplexhub.rsql.jsonb.JsonbPathSupport;
+import io.github.perplexhub.rsql.model.PostgresJsonEntity;
+import io.github.perplexhub.rsql.repository.jpa.postgres.PostgresJsonEntityRepository;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.orm.jpa.vendor.Database;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import static io.github.perplexhub.rsql.RSQLJPASupport.toSpecification;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static io.github.perplexhub.rsql.RSQLJPASupportPostgresJsonTest.*;
+
+@SpringBootTest
+@ActiveProfiles("postgres13")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+class RSQLJPASupportPostgresJsonPathTest {
+
+    @Autowired
+    private PostgresJsonEntityRepository repository;
+
+    @BeforeEach
+    void setup(@Autowired EntityManager em) {
+        RSQLVisitorBase.setEntityManagerDatabase(Map.of(em, Database.POSTGRESQL));
+    }
+
+    @AfterEach
+    void tearDown() {
+        repository.deleteAll();
+        repository.flush();
+        RSQLVisitorBase.setEntityManagerDatabase(Map.of());
+    }
+
+    @ParameterizedTest
+    @MethodSource("data")
+    void testJson(List<PostgresJsonEntity> entities, String rsql, List<PostgresJsonEntity> expected) {
+        //given
+        repository.saveAllAndFlush(entities);
+
+        //when
+        List<PostgresJsonEntity> result = repository.findAll(toSpecification(JsonbPathSupport.query(rsql)));
+
+        //then
+        assertThat(result)
+                .hasSameSizeAs(expected)
+                .containsExactlyInAnyOrderElementsOf(expected);
+
+        entities.forEach(e -> e.setId(null));
+    }
+
+    static Stream<Arguments> data() {
+        return Stream.of(equalsData(),
+                inData(),
+                betweenData(),
+                likeData(),
+                gtLtData(),
+                miscData(),
+                textData(),
+                booleanData(),
+                numberData(),
+                dateData(),
+                timeData(),
+                dateTimeWithTzData(),
+                dateTimeWithoutTzData(),
+                arrayData(),
+                doesNotConvertBoolean(),
+                doesNotConvertInteger(),
+                nestedObjets(),
+                null
+        ).filter(Objects::nonNull).flatMap(s -> s);
+    }
+
+    private static Stream<Arguments> textData() {
+        var e1 = new PostgresJsonEntity(Map.of("a", "Lorem"));
+        var e2 = new PostgresJsonEntity(Map.of("a", "Ipsum"));
+        var e3 = new PostgresJsonEntity(Map.of("a", "Dolor"));
+        var e4 = new PostgresJsonEntity(Map.of("a", "Sit"));
+        var e5 = new PostgresJsonEntity(Map.of("a", "Amet"));
+        var e6 = new PostgresJsonEntity(Map.of("a", "Consectetur adipiscing elit"));
+        var allCases = List.of(e1, e2, e3, e4, e5, e6);
+        return Stream.of(
+                arguments(allCases, "properties.a=like=Lorem", List.of(e1)),
+                arguments(allCases, "properties.a=like='Consectetur adipiscing elit'", List.of(e6)),
+                arguments(allCases, "properties.a=notlike=Lorem", List.of(e2, e3, e4, e5, e6)),
+                arguments(allCases, "properties.a=like=*t", List.of(e4, e5, e6)),
+                arguments(allCases, "properties.a=like=*o*", List.of(e1, e3, e6)),
+                arguments(allCases, "properties.a=icase=dolor", List.of(e3)),
+                arguments(allCases, "properties.a=inotlike=dolor", List.of(e1, e2, e4, e5, e6)),
+                null
+        ).filter(Objects::nonNull);
+    }
+
+
+    private static Stream<Arguments> booleanData() {
+        var e1 = new PostgresJsonEntity(Map.of("a", true));
+        var e2 = new PostgresJsonEntity(Map.of("a", false));
+        var e3 = new PostgresJsonEntity(Map.of("a", true));
+        var e4 = new PostgresJsonEntity(Map.of("a", false));
+        var e5 = new PostgresJsonEntity(nullMap("a"));
+        var e6 = new PostgresJsonEntity(Map.of("b", "other"));
+        var allCases = List.of(e1, e2, e3, e4, e5, e6);
+        return Stream.of(
+                arguments(allCases, "properties.a==true", List.of(e1, e3)),
+                arguments(allCases, "properties.a==false", List.of(e2, e4)),
+                arguments(allCases, "properties.a!=true", List.of(e2, e4, e5, e6)),
+                arguments(allCases, "properties.a!=false", List.of(e1, e3, e5, e6)),
+                null
+        ).filter(Objects::nonNull);
+    }
+
+    static Stream<Arguments> numberData() {
+        var e1 = new PostgresJsonEntity(Map.of("a1", 1));
+        var e2 = new PostgresJsonEntity(Map.of("a1", 2));
+        var e3 = new PostgresJsonEntity(Map.of("a1", 3));
+        var e4 = new PostgresJsonEntity(Map.of("a1", 3.14));
+        var e5 = new PostgresJsonEntity(Map.of("a1", 42));
+        var allCases = List.of(e1, e2, e3, e4, e5);
+        return Stream.of(
+                arguments(allCases, "properties.a1==1", List.of(e1)),
+                arguments(allCases, "properties.a1==42", List.of(e5)),
+                arguments(allCases, "properties.a1=ge=2", List.of(e2, e3, e4, e5)),
+                arguments(allCases, "properties.a1=gt=2", List.of(e3, e4, e5)),
+                arguments(allCases, "properties.a1=le=2", List.of(e1, e2)),
+                arguments(allCases, "properties.a1=lt=2", List.of(e1)),
+                arguments(allCases, "properties.a1=in=(1,2)", List.of(e1, e2)),
+                arguments(allCases, "properties.a1=out=(1,2)", List.of(e3, e4, e5)),
+                arguments(allCases, "properties.a1=bt=(3,4)", List.of(e3, e4)),
+                arguments(allCases, "properties.a1=nb=(3,4)", List.of(e1, e2, e5)),
+                null
+        ).filter(Objects::nonNull);
+    }
+
+    protected static Stream<Arguments> dateData() {
+        var e1 = new PostgresJsonEntity(Map.of("a", "1970-01-01"));
+        var e2 = new PostgresJsonEntity(Map.of("a", "2000-01-01"));
+        var e3 = new PostgresJsonEntity(Map.of("a", "2020-01-01"));
+        var e4 = new PostgresJsonEntity(Map.of("a", "2020-01-02"));
+        var e5 = new PostgresJsonEntity(nullMap("a"));
+        var e6 = new PostgresJsonEntity(Map.of("b", "other"));
+        var e7 = new PostgresJsonEntity(Map.of("a", "not a date"));
+        var allCases = List.of(e1, e2, e3, e4, e5, e6, e7);
+        return Stream.of(
+                arguments(allCases, "properties.a==1970-01-01", List.of(e1)),
+                arguments(allCases, "properties.a=gt=1970-01-01", List.of(e2, e3, e4)),
+                arguments(allCases, "properties.a>=1970-01-01", List.of(e1, e2, e3, e4)),
+                arguments(allCases, "properties.a<1970-01-01", List.of()),
+                arguments(allCases, "properties.a!=2020-01-01", List.of(e1, e2, e4, e5, e6, e7)),
+                arguments(allCases, "properties.a=bt=(1970-01-01, 2020-01-01)", List.of(e1, e2, e3)),
+                arguments(allCases, "properties.a=nb=(1970-01-01, 2020-01-01)", List.of(e4, e5, e6, e7)),
+                null
+        ).filter(Objects::nonNull);
+    }
+
+    protected static Stream<Arguments> timeData() {
+        var e1 = new PostgresJsonEntity(Map.of("a", "00:00:00"));
+        var e2 = new PostgresJsonEntity(Map.of("a", "01:00:00"));
+        var e3 = new PostgresJsonEntity(Map.of("a", "02:00:00"));
+        var e4 = new PostgresJsonEntity(Map.of("a", "03:00:00"));
+        var e5 = new PostgresJsonEntity(nullMap("a"));
+        var e6 = new PostgresJsonEntity(Map.of("b", "other"));
+        var e7 = new PostgresJsonEntity(Map.of("a", "not a time"));
+        var allCases = List.of(e1, e2, e3, e4, e5, e6, e7);
+        return Stream.of(
+                arguments(allCases, "properties.a==00:00:00", List.of(e1)),
+                arguments(allCases, "properties.a=gt=00:00:00", List.of(e2, e3, e4)),
+                arguments(allCases, "properties.a>=00:00:00", List.of(e1, e2, e3, e4)),
+                arguments(allCases, "properties.a<00:00:00", List.of()),
+                arguments(allCases, "properties.a=bt=(00:00:00, 02:00:00)", List.of(e1, e2, e3)),
+                arguments(allCases, "properties.a=nb=(00:00:00, 02:00:00)", List.of(e4, e5, e6, e7)),
+                null
+        ).filter(Objects::nonNull);
+    }
+
+    protected static Stream<Arguments> dateTimeWithTzData() {
+        var e1 = new PostgresJsonEntity(Map.of("a", "1970-01-01T00:00:00+00:00"));
+        var e2 = new PostgresJsonEntity(Map.of("a", "2000-01-01T00:00:00+00:00"));
+        var e3 = new PostgresJsonEntity(Map.of("a", "2020-01-01T00:00:00+00:00"));
+        var e4 = new PostgresJsonEntity(Map.of("a", "2020-01-01T01:00:00+00:00"));
+        var e5 = new PostgresJsonEntity(nullMap("a"));
+        var e6 = new PostgresJsonEntity(Map.of("b", "other"));
+        var allCases = List.of(e1, e2, e3, e4, e5, e6);
+        return Stream.of(
+                arguments(allCases, "properties.a==1970-01-01T00:00:00+00:00", List.of(e1)),
+                arguments(allCases, "properties.a=gt=1970-01-01T00:00:00+00:00", List.of(e2, e3, e4)),
+                arguments(allCases, "properties.a>=1970-01-01T00:00:00+00:00", List.of(e1, e2, e3, e4)),
+                arguments(allCases, "properties.a<2020-01-01T00:00:00+00:00", List.of(e1, e2)),
+                null
+        ).filter(Objects::nonNull);
+    }
+
+    protected static Stream<Arguments> dateTimeWithoutTzData() {
+        var e1 = new PostgresJsonEntity(Map.of("a", "1970-01-01T00:00:00"));
+        var e2 = new PostgresJsonEntity(Map.of("a", "2000-01-01T00:00:00"));
+        var e3 = new PostgresJsonEntity(Map.of("a", "2020-01-01T00:00:00"));
+        var e4 = new PostgresJsonEntity(Map.of("a", "2020-01-01T01:00:00"));
+        var e5 = new PostgresJsonEntity(nullMap("a"));
+        var e6 = new PostgresJsonEntity(Map.of("b", "other"));
+        var allCases = List.of(e1, e2, e3, e4, e5, e6);
+        return Stream.of(
+                arguments(allCases, "properties.a==1970-01-01T00:00:00", List.of(e1)),
+                arguments(allCases, "properties.a=gt=1970-01-01T00:00:00", List.of(e2, e3, e4)),
+                arguments(allCases, "properties.a>=1970-01-01T00:00:00", List.of(e1, e2, e3, e4)),
+                arguments(allCases, "properties.a<2020-01-01T00:00:00", List.of(e1, e2)),
+                null
+        ).filter(Objects::nonNull);
+    }
+
+    private static Stream<Arguments> arrayData() {
+        var e1 = new PostgresJsonEntity(Map.of("a", List.of(1, 2, 3)));
+        var e2 = new PostgresJsonEntity(Map.of("a", List.of(4, 5, 6)));
+        var e3 = new PostgresJsonEntity(Map.of("a", List.of(7, 8, 9)));
+        var allCases = List.of(e1, e2, e3);
+        return Stream.of(
+                arguments(allCases, "properties.a==1", List.of(e1)),
+                arguments(allCases, "properties.a==4", List.of(e2)),
+                arguments(allCases, "properties.a!=1", List.of(e2, e3)),
+                arguments(allCases, "properties.a!=4", List.of(e1, e3)),
+                arguments(allCases, "properties.a=in=(1,4)", List.of(e1, e2)),
+                arguments(allCases, "properties.a=out=(1,4)", List.of(e3)),
+                null
+        ).filter(Objects::nonNull);
+    }
+
+    private static Stream<Arguments> nestedObjets() {
+        var e1 = new PostgresJsonEntity(Map.of("a", Map.of("b", Map.of("c", 1))));
+        var e2 = new PostgresJsonEntity(Map.of("a", Map.of("b", Map.of("c", 2))));
+        var e3 = new PostgresJsonEntity(Map.of("a", Map.of("b", Map.of("c", 3))));
+        var allCases = List.of(e1, e2, e3);
+        return Stream.of(
+                arguments(allCases, "properties.a.b.c==1", List.of(e1)),
+                arguments(allCases, "properties.a.b.c==2", List.of(e2)),
+                arguments(allCases, "properties.a.b.c!=1", List.of(e2, e3)),
+                arguments(allCases, "properties.a.b.c!=2", List.of(e1, e3)),
+                arguments(allCases, "properties.a.b.c=in=(1,2)", List.of(e1, e2)),
+                arguments(allCases, "properties.a.b.c=out=(1,2)", List.of(e3)),
+                arguments(allCases, "properties.a.b.c=bt=(1,2)", List.of(e1, e2)),
+                arguments(allCases, "properties.a.b.c=nb=(1,2)", List.of(e3)),
+                null
+        ).filter(Objects::nonNull);
+    }
+
+    private static Stream<Arguments> doesNotConvertBoolean() {
+        var e1 = new PostgresJsonEntity(Map.of("a", "true"));
+        var e2 = new PostgresJsonEntity(Map.of("a", "false"));
+        var e3 = new PostgresJsonEntity(Map.of("a", "other"));
+        var allCases = List.of(e1, e2, e3);
+        return Stream.of(
+                arguments(allCases, "properties.a=like=true", List.of(e1)),
+                arguments(allCases, "properties.a=like=false", List.of(e2)),
+                arguments(allCases, "properties.a=in=(true,false)", List.of()),
+                arguments(allCases, "properties.a=notlike=true", List.of(e2, e3)),
+                null
+        ).filter(Objects::nonNull);
+    }
+
+    private static Stream<Arguments> doesNotConvertInteger() {
+        var e1 = new PostgresJsonEntity(Map.of("a", "1"));
+        var e2 = new PostgresJsonEntity(Map.of("a", "2"));
+        var e3 = new PostgresJsonEntity(Map.of("a", "other"));
+        var allCases = List.of(e1, e2, e3);
+        return Stream.of(
+                arguments(allCases, "properties.a=like=1", List.of(e1)),
+                arguments(allCases, "properties.a=like=2", List.of(e2)),
+                arguments(allCases, "properties.a=in=(1,2)", List.of()),
+                arguments(allCases, "properties.a=notlike=1", List.of(e2, e3)),
+                null
+        ).filter(Objects::nonNull);
+    }
+
+    private static Map<String, Object> nullMap(String key) {
+        HashMap<String, Object> nullValue = new HashMap<>();
+        nullValue.put(key, null);
+        return nullValue;
+    }
+}

--- a/rsql-jpa/src/test/java/io/github/perplexhub/rsql/RSQLJPASupportPostgresJsonTest.java
+++ b/rsql-jpa/src/test/java/io/github/perplexhub/rsql/RSQLJPASupportPostgresJsonTest.java
@@ -18,10 +18,12 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.orm.jpa.vendor.Database;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
 @ActiveProfiles("postgres")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class RSQLJPASupportPostgresJsonTest {
 
   @Autowired
@@ -68,7 +70,7 @@ class RSQLJPASupportPostgresJsonTest {
         .flatMap(s -> s);
   }
 
-  private static Stream<Arguments> equalsData() {
+  static Stream<Arguments> equalsData() {
     var e1 = new PostgresJsonEntity(Map.of("a1", "b1"));
     var e2 = new PostgresJsonEntity(Map.of("a1", Map.of("a11", Map.of("a111", "b1"))));
 
@@ -93,7 +95,7 @@ class RSQLJPASupportPostgresJsonTest {
     );
   }
 
-  private static Stream<Arguments> inData() {
+  static Stream<Arguments> inData() {
     var e1 = new PostgresJsonEntity(Map.of("a", "b1"));
     var e2 = new PostgresJsonEntity(Map.of("a", "b2"));
     var e3 = new PostgresJsonEntity(Map.of("a", "c1"));
@@ -107,7 +109,7 @@ class RSQLJPASupportPostgresJsonTest {
     );
   }
 
-  private static Stream<Arguments> betweenData() {
+  static Stream<Arguments> betweenData() {
     var e1 = new PostgresJsonEntity(Map.of("a", "a"));
     var e2 = new PostgresJsonEntity(Map.of("a", "b"));
     var e3 = new PostgresJsonEntity(Map.of("a", "c"));
@@ -119,7 +121,7 @@ class RSQLJPASupportPostgresJsonTest {
     );
   }
 
-  private static Stream<Arguments> likeData() {
+  static Stream<Arguments> likeData() {
     var e1 = new PostgresJsonEntity(Map.of("a", "a b c"));
     var e2 = new PostgresJsonEntity(Map.of("a", "b c d"));
     var e3 = new PostgresJsonEntity(Map.of("a", "c d e"));
@@ -140,7 +142,7 @@ class RSQLJPASupportPostgresJsonTest {
     );
   }
 
-  private static Stream<Arguments> gtLtData() {
+  static Stream<Arguments> gtLtData() {
     var e1 = new PostgresJsonEntity(Map.of("a", "a"));
     var e2 = new PostgresJsonEntity(Map.of("a", "b"));
     var e3 = new PostgresJsonEntity(Map.of("a", "c"));
@@ -156,7 +158,7 @@ class RSQLJPASupportPostgresJsonTest {
     );
   }
 
-  private static Stream<Arguments> miscData() {
+  static Stream<Arguments> miscData() {
     var e1 = new PostgresJsonEntity(Map.of("a", "b1"));
     var e2 = new PostgresJsonEntity(Map.of("a", "b2"));
     var e3 = new PostgresJsonEntity(Map.of("b", "c1"));

--- a/rsql-jpa/src/test/java/io/github/perplexhub/rsql/RSQLJPASupportTest.java
+++ b/rsql-jpa/src/test/java/io/github/perplexhub/rsql/RSQLJPASupportTest.java
@@ -25,6 +25,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.domain.Specification;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.MultiValueMap;
 
@@ -40,6 +41,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @SpringBootTest
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class RSQLJPASupportTest {
 
 	@Autowired

--- a/rsql-jpa/src/test/resources/application-postgres13.yml
+++ b/rsql-jpa/src/test/resources/application-postgres13.yml
@@ -1,0 +1,11 @@
+spring:
+  datasource:
+    driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
+    url: jdbc:tc:postgresql:13://localhost/test
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+        hibernate:
+          dialect: org.hibernate.dialect.PostgreSQLDialect
+          show_sql: true


### PR DESCRIPTION
Add support for jsonb_path_exists on jsonb columns using custom predicate

Manage json type
- number
- date
- boolean

The implementation uses custom predicate

```java
List<PostgresJsonEntity> result = repository.findAll(toSpecification(JsonbPathSupport.query(rsql)));
```

>This PR must be merged after #124 and #125 