### PR TITLE
Bump rsql-parser version to v2.3.2.

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,12 +146,12 @@ filter = "company.id>100"; //greater than
 filter = "company.id<100"; //less than
 filter = "company.id>=100"; //greater than or equal
 filter = "company.id<=100"; //less than or equal
-filter = "company.code=isnull=''"; //is null
-filter = "company.code=null=''"; //is null
-filter = "company.code=na=''"; //is null
-filter = "company.code=nn=''"; //is not null
-filter = "company.code=notnull=''"; //is not null
-filter = "company.code=isnotnull=''"; //is not null
+filter = "company.code=isnull="; //is null
+filter = "company.code=null="; //is null
+filter = "company.code=na="; //is null
+filter = "company.code=nn="; //is not null
+filter = "company.code=notnull="; //is not null
+filter = "company.code=isnotnull="; //is not null
 
 filter = "company.code=='demo';company.id>100"; //and
 filter = "company.code=='demo' and company.id>100"; //and

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 		<spring-boot.version>3.0.0</spring-boot.version>
 		<spring-data-releasetrain.version>2022.0.0</spring-data-releasetrain.version>
 		<querydsl.version>4.1.4</querydsl.version>
-		<rsql-parser.version>2.2.1</rsql-parser.version>
+		<rsql-parser.version>2.3.2</rsql-parser.version>
 		<lombok.version>1.18.24</lombok.version>
 		<hamcrest.version>2.2</hamcrest.version>
 		<h2.version>2.2.220</h2.version>

--- a/rsql-common/src/main/java/io/github/perplexhub/rsql/RSQLOperators.java
+++ b/rsql-common/src/main/java/io/github/perplexhub/rsql/RSQLOperators.java
@@ -1,5 +1,6 @@
 package io.github.perplexhub.rsql;
 
+import cz.jirutka.rsql.parser.ast.Arity;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -15,17 +16,17 @@ public class RSQLOperators {
 			GREATER_THAN_OR_EQUAL = new ComparisonOperator("=ge=", ">="),
 			LESS_THAN = new ComparisonOperator("=lt=", "<"),
 			LESS_THAN_OR_EQUAL = new ComparisonOperator("=le=", "<="),
-			IN = new ComparisonOperator("=in=", true),
-			NOT_IN = new ComparisonOperator("=out=", true),
-			IS_NULL = new ComparisonOperator("=na=", "=isnull=", "=null="),
-			NOT_NULL = new ComparisonOperator("=nn=", "=notnull=", "=isnotnull="),
+			IN = new ComparisonOperator("=in=", Arity.of(1, Integer.MAX_VALUE)),
+			NOT_IN = new ComparisonOperator("=out=", Arity.of(1, Integer.MAX_VALUE)),
+			IS_NULL = new ComparisonOperator(new String[]{"=na=", "=isnull=", "=null="}, Arity.of(0, 1)),
+			NOT_NULL = new ComparisonOperator(new String[]{"=nn=", "=notnull=", "=isnotnull="}, Arity.of(0, 1)),
 			LIKE = new ComparisonOperator("=ke=", "=like="),
 			NOT_LIKE = new ComparisonOperator("=nk=", "=notlike="),
 			IGNORE_CASE = new ComparisonOperator("=ic=", "=icase="),
 			IGNORE_CASE_LIKE = new ComparisonOperator("=ik=", "=ilike="),
 			IGNORE_CASE_NOT_LIKE = new ComparisonOperator("=ni=", "=inotlike="),
-			BETWEEN = new ComparisonOperator("=bt=", "=between=", true),
-			NOT_BETWEEN = new ComparisonOperator("=nb=", "=notbetween=", true);
+			BETWEEN = new ComparisonOperator("=bt=", "=between=", Arity.nary(2)),
+			NOT_BETWEEN = new ComparisonOperator("=nb=", "=notbetween=", Arity.nary(2));
 
   private static final Set<ComparisonOperator> OPERATORS = Collections.unmodifiableSet(
       new HashSet<>(Arrays.asList(EQUAL, NOT_EQUAL,

--- a/rsql-jpa/src/main/java/io/github/perplexhub/rsql/RSQLJPAPredicateConverter.java
+++ b/rsql-jpa/src/main/java/io/github/perplexhub/rsql/RSQLJPAPredicateConverter.java
@@ -302,12 +302,12 @@ public class RSQLJPAPredicateConverter extends RSQLVisitorBase<Predicate, From> 
 			if (op.equals(NOT_IN)) {
 				return expression.in(listObject).not();
 			}
-			if (op.equals(BETWEEN) && listObject.size() == 2
+			if (op.equals(BETWEEN)
 				&& listObject.get(0) instanceof Comparable comp1
 				&& listObject.get(1) instanceof Comparable comp2) {
 				return builder.between(expression, comp1, comp2);
 			}
-			if (op.equals(NOT_BETWEEN) && listObject.size() == 2 &&
+			if (op.equals(NOT_BETWEEN) &&
 				listObject.get(0) instanceof Comparable comp1
 				&& listObject.get(1) instanceof Comparable comp2) {
 				return builder.between(expression, comp1, comp2).not();

--- a/rsql-jpa/src/test/java/io/github/perplexhub/rsql/RSQLJPASupportTest.java
+++ b/rsql-jpa/src/test/java/io/github/perplexhub/rsql/RSQLJPASupportTest.java
@@ -28,6 +28,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Page;
@@ -504,53 +506,37 @@ class RSQLJPASupportTest {
 		assertThat(rsql, count, is(7L));
 	}
 
-	@Test
-	final void testIsNull() {
-		String rsql = "name=isnull=''";
+	@ParameterizedTest
+	@ValueSource(strings = {
+			"name=isnull=''",
+			"name=isnull=",
+			"name=null=''",
+			"name=null=",
+			"name=na=''",
+			"name=na=",
+	})
+	final void testIsNull(String rsql) {
 		List<Company> companys = companyRepository.findAll(toSpecification(rsql));
 		long count = companys.size();
-		log.info("rsql: {} -> count: {}", rsql, count);
-		assertThat(rsql, count, is(1L));
-		assertThat(rsql, companys.get(0).getCode(), equalTo("null"));
-		assertThat(rsql, companys.get(0).getName(), is(nullValue()));
 
-		rsql = "name=null=''";
-		companys = companyRepository.findAll(toSpecification(rsql));
-		count = companys.size();
-		log.info("rsql: {} -> count: {}", rsql, count);
-		assertThat(rsql, count, is(1L));
-		assertThat(rsql, companys.get(0).getCode(), equalTo("null"));
-		assertThat(rsql, companys.get(0).getName(), is(nullValue()));
-
-		rsql = "name=na=''";
-		companys = companyRepository.findAll(toSpecification(rsql));
-		count = companys.size();
-		log.info("rsql: {} -> count: {}", rsql, count);
 		assertThat(rsql, count, is(1L));
 		assertThat(rsql, companys.get(0).getCode(), equalTo("null"));
 		assertThat(rsql, companys.get(0).getName(), is(nullValue()));
 	}
 
-	@Test
-	final void testIsNotNull() {
-		String rsql = "name=isnotnull=''";
+	@ParameterizedTest
+	@ValueSource(strings = {
+			"name=isnotnull=''",
+			"name=isnotnull=",
+			"name=notnull=''",
+			"name=notnull=",
+			"name=nn=''",
+			"name=nn="
+	})
+	final void testIsNotNull(String rsql) {
 		List<Company> companys = companyRepository.findAll(toSpecification(rsql));
 		long count = companys.size();
-		log.info("rsql: {} -> count: {}", rsql, count);
-		assertThat(rsql, count, is(6L));
-		assertThat(rsql, companys.get(0).getName(), is(notNullValue()));
 
-		rsql = "name=notnull=''";
-		companys = companyRepository.findAll(toSpecification(rsql));
-		count = companys.size();
-		log.info("rsql: {} -> count: {}", rsql, count);
-		assertThat(rsql, count, is(6L));
-		assertThat(rsql, companys.get(0).getName(), is(notNullValue()));
-
-		rsql = "name=nn=''";
-		companys = companyRepository.findAll(toSpecification(rsql));
-		count = companys.size();
-		log.info("rsql: {} -> count: {}", rsql, count);
 		assertThat(rsql, count, is(6L));
 		assertThat(rsql, companys.get(0).getName(), is(notNullValue()));
 	}


### PR DESCRIPTION
The rsql-parser:2.3.1 contains notable improvement of having unary operators like `=null=` and `=notnull=`.

Previously we've been forced to `company.code=notnull=''` because parser didn't allow no argument operator. With v2.3.1
it becomes possible so above query becomes  `company.code=notnull=`.

However, we still accept `=notnull=''` version to not break user queries but I believe we should be remove it in the future releases.