### PR TITLE
Use Hibernates case-insensitive pattern matching when available.

### DIFF
--- a/rsql-jpa/src/main/java/io/github/perplexhub/rsql/HibernateSupport.java
+++ b/rsql-jpa/src/main/java/io/github/perplexhub/rsql/HibernateSupport.java
@@ -1,0 +1,32 @@
+package io.github.perplexhub.rsql;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Predicate;
+import org.hibernate.query.criteria.HibernateCriteriaBuilder;
+import org.springframework.util.ClassUtils;
+
+final class HibernateSupport {
+
+  private static final boolean isHibernatePresent = ClassUtils.isPresent(
+      "org.hibernate.query.criteria.HibernateCriteriaBuilder", HibernateSupport.class.getClassLoader());
+
+  private HibernateSupport() {
+  }
+
+  static boolean isHibernateCriteriaBuilder(CriteriaBuilder cb) {
+    return isHibernatePresent && cb instanceof HibernateCriteriaBuilder;
+  }
+
+  /**
+   * Must be guarded with {@linkplain #isHibernatePresent} before invoking.
+   */
+  static Predicate ilike(CriteriaBuilder cb, Expression<String> expression, String arg, Character escapeChar) {
+    var hcb = (HibernateCriteriaBuilder) cb;
+    var pattern = '%' + arg + '%';
+
+    return escapeChar != null
+        ? hcb.ilike(expression, pattern, escapeChar)
+        : hcb.ilike(expression, pattern);
+  }
+}


### PR DESCRIPTION
This commit provides case-insensitive pattern matching when using `=ilike=` or `=inotlike=` that relies on Hibernate's implementation for `ilike`. However, if JPA provider is different from Hibernate we fallback to old implementation.

The reason behind this change is to allow Hibernate generate "proper" case-insensitive pattern matching query depending on database.