### PR TITLE
WIP: Spring boot 4 bump

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,8 +23,8 @@
 		<java.version>17</java.version>
 		<maven.compiler.target>17</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<spring-boot.version>3.4.1</spring-boot.version>
-		<spring-data-releasetrain.version>2024.1.1</spring-data-releasetrain.version>
+		<spring-boot.version>4.0.0</spring-boot.version>
+		<spring-data-releasetrain.version>2025.1.0</spring-data-releasetrain.version>
 		<querydsl.version>4.1.4</querydsl.version>
 		<rsql-parser.version>2.3.3</rsql-parser.version>
 		<lombok.version>1.18.24</lombok.version>

--- a/rsql-common/pom.xml
+++ b/rsql-common/pom.xml
@@ -34,8 +34,8 @@
 		</dependency>
 		<dependency>
 			<groupId>io.hypersistence</groupId>
-			<artifactId>hypersistence-utils-hibernate-63</artifactId>
-			<version>3.9.0</version>
+			<artifactId>hypersistence-utils-hibernate-71</artifactId>
+			<version>3.12.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/rsql-jpa-spring-boot-starter/src/main/java/io/github/perplexhub/rsql/RSQLJPAAutoConfiguration.java
+++ b/rsql-jpa-spring-boot-starter/src/main/java/io/github/perplexhub/rsql/RSQLJPAAutoConfiguration.java
@@ -12,12 +12,12 @@ import java.util.Objects;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.Session;
-import org.hibernate.dialect.AbstractHANADialect;
 import org.hibernate.dialect.CockroachDialect;
 import org.hibernate.dialect.DB2Dialect;
-import org.hibernate.dialect.DerbyDialect;
+// import org.hibernate.dialect.DerbyDialect;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.H2Dialect;
+import org.hibernate.dialect.HANADialect;
 import org.hibernate.dialect.HSQLDialect;
 import org.hibernate.dialect.MySQLDialect;
 import org.hibernate.dialect.OracleDialect;
@@ -80,13 +80,13 @@ public class RSQLJPAAutoConfiguration {
         return Database.SQL_SERVER;
       } else if (dialect instanceof OracleDialect) {
         return Database.ORACLE;
-      } else if (dialect instanceof DerbyDialect) {
-        return Database.DERBY;
+      // } else if (dialect instanceof DerbyDialect) {
+      //   return Database.DERBY;
       } else if (dialect instanceof DB2Dialect) {
         return Database.DB2;
       } else if (dialect instanceof H2Dialect) {
         return Database.H2;
-      } else if (dialect instanceof AbstractHANADialect) {
+      } else if (dialect instanceof HANADialect) {
         return Database.HANA;
       } else if (dialect instanceof HSQLDialect) {
         return Database.HSQL;

--- a/rsql-jpa/pom.xml
+++ b/rsql-jpa/pom.xml
@@ -29,6 +29,12 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>org.springframework.boot</groupId>
+					<artifactId>spring-boot-jackson</artifactId>
+				</exclusion>
+			</exclusions>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -54,8 +60,14 @@
 		</dependency>
 		<dependency>
 			<groupId>io.hypersistence</groupId>
-			<artifactId>hypersistence-utils-hibernate-63</artifactId>
-			<version>3.9.0</version>
+			<artifactId>hypersistence-utils-hibernate-71</artifactId>
+			<version>3.12.0</version>
+			<scope>test</scope>
+		</dependency>
+		<!-- required by hypersistence, since they don't support jackson 3 -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-jackson2</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
Bumping the dependencies to support Spring boot 4. There are two major things that Spring boot 4 brings in which affects this upgrade (full list of deps can be found [here](https://docs.spring.io/spring-boot/4.0-SNAPSHOT/appendix/dependency-versions/coordinates.html)):

- Hibernate 6 -> 7
- Jackson 2 -> 3

As I've mentioned in [this issue](https://github.com/perplexhub/rsql-jpa-specification/issues/192), Hibernate 7 moves some dialects to a separate community jar.

I'm ignoring `DerbyDialect` for now.

Jackson 3 wouldn't be an issue, except for the fact that we use `hypersistence-utils-hibernate-XX` for testing. It seems the library only supports [Jackson 2](https://github.com/vladmihalcea/hypersistence-utils/issues/810) and Vlad doesn't want to upgrade it just yet.

I got around this by forcing Spring to use Jackson 2 for the tests, [as suggested by the Spring boot 4.0 migration guide](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-4.0-Migration-Guide#jackson-2-compatibility) (check the changes in `rsql-jpa/pom.xml`). That seems to get the test running.

However, I get some test errors that I have no idea how to solve (I'm not a hibernate expert by any means).

For example:

```
[ERROR]   RSQLJPASupportTest.testJoinHints:175 » InvalidDataAccessApiUsage Could not resolve attribute 'departmentName' of 'io.github.perplexhub.rsql.model.Project'
```

It seems that in the previous version we could query for the `departmentName` attribute, assuming it exists in one of the children of the `Project` class hierarchy(`deparmentName` is an attribute of the `AdminProject`, but not of the `DesignProject`).

Maybe something changed in hibernate 7? 

Let me know what you think @nstdio.