### PR TITLE
Preserve textual operator arguments

### DIFF
--- a/rsql-common/src/test/java/io/github/perplexhub/rsql/model/User.java
+++ b/rsql-common/src/test/java/io/github/perplexhub/rsql/model/User.java
@@ -2,6 +2,7 @@ package io.github.perplexhub.rsql.model;
 
 import java.util.Date;
 import java.util.List;
+import java.util.UUID;
 
 import jakarta.persistence.*;
 
@@ -21,6 +22,8 @@ public class User {
 	private Integer id;
 
 	private String name;
+
+	private UUID externalId;
 
 	@ManyToOne
 	@JoinColumn(name = "companyId", referencedColumnName = "id")

--- a/rsql-common/src/test/resources/import_user.sql
+++ b/rsql-common/src/test/resources/import_user.sql
@@ -1,4 +1,4 @@
-insert into users(id, name, company_id, create_date, status, city_id) values(1, 'January', 1, '2018-01-01', 'STARTED', 1);
+insert into users(id, name, company_id, create_date, status, city_id, external_id) values(1, 'January', 1, '2018-01-01', 'STARTED', 1, '11111111-1111-4111-8111-111111111111');
 insert into users(id, name, company_id, create_date, status, city_id) values(2, 'February', 1, '2018-02-01', 'STARTED', 2);
 insert into users(id, name, company_id, create_date, status, city_id) values(3, 'March', 2, '2018-03-01', 'STARTED', 3);
 insert into users(id, name, company_id, create_date, status) values(4, 'April', 2, '2018-04-01', 'STARTED');
@@ -7,6 +7,6 @@ insert into users(id, name, company_id, create_date, status) values(6, 'June', 2
 insert into users(id, name, company_id, create_date, status) values(7, 'July', 3, '2018-07-01', 'ACTIVE');
 insert into users(id, name, company_id, create_date, status) values(8, 'August', 3, '2018-08-01', 'ACTIVE');
 insert into users(id, name, company_id, create_date, status) values(9, 'September', 4, '2018-09-01', 'ACTIVE');
-insert into users(id, name, company_id, create_date, status) values(10, 'October', 5, '2018-10-01', 'FINISHED');
+insert into users(id, name, company_id, create_date, status, external_id) values(10, 'October', 5, '2018-10-01', 'FINISHED', 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa');
 insert into users(id, name, company_id, create_date, status) values(11, 'November', 5, '2018-11-01', 'FINISHED');
 insert into users(id, name, company_id, create_date, status) values(12, 'December', 5, '2018-12-01', 'CANCELLED');

--- a/rsql-jpa/src/main/java/io/github/perplexhub/rsql/RSQLJPAPredicateConverter.java
+++ b/rsql-jpa/src/main/java/io/github/perplexhub/rsql/RSQLJPAPredicateConverter.java
@@ -266,13 +266,7 @@ public class RSQLJPAPredicateConverter extends RSQLVisitorBase<Predicate, From> 
 					ComparisonNode jsonbNode = node.withSelector(jsonbPath);
 					return JsonbSupport.jsonbPathExistsExpression(builder, jsonbNode, path, jsonbConfiguration);
 				} else {
-					final Expression expression;
-					if (path instanceof JpaExpression jpaExpression) {
-						expression = jpaExpression.cast(String.class);
-					} else {
-						expression = path.as(String.class);
-					}
-					return ResolvedExpression.ofPath(expression, String.class);
+					return ResolvedExpression.ofPath(textualExpression(path), String.class);
 				}
 			} else {
 				if (attribute != null
@@ -350,7 +344,8 @@ public class RSQLJPAPredicateConverter extends RSQLVisitorBase<Predicate, From> 
 			if (op.equals(NOT_NULL)) {
 				return builder.isNotNull(expression);
 			}
-			Object argument = convert(arguments.get(0), type);
+			boolean preserveTextualArgument = preservesTextualArgument(op);
+			Object argument = preserveTextualArgument ? arguments.get(0) : convert(arguments.get(0), type);
 			if (op.equals(IN)) {
 				return builder.equal(expression, argument);
 			}
@@ -364,7 +359,7 @@ public class RSQLJPAPredicateConverter extends RSQLVisitorBase<Predicate, From> 
 				return likePredicate(expression, argument, false).not();
 			}
 			if (op.equals(IGNORE_CASE)) {
-				return builder.equal(builder.upper(expression), argument.toString().toUpperCase());
+				return ignoreCasePredicate(expression, argument);
 			}
 			if (op.equals(IGNORE_CASE_LIKE)) {
 				return likePredicate(expression, argument, true);
@@ -402,6 +397,15 @@ public class RSQLJPAPredicateConverter extends RSQLVisitorBase<Predicate, From> 
 	}
 
 	/**
+	 * Operators that compare the textual representation of an expression must keep their
+	 * RSQL argument raw instead of converting it to the expression's Java type first.
+	 */
+	static boolean preservesTextualArgument(ComparisonOperator op) {
+		return op.equals(LIKE) || op.equals(NOT_LIKE) || op.equals(IGNORE_CASE)
+				|| op.equals(IGNORE_CASE_LIKE) || op.equals(IGNORE_CASE_NOT_LIKE);
+	}
+
+	/**
 	 * Convert a like expression to a like predicate
 	 *
 	 * @param attributePath The attribute path
@@ -416,7 +420,7 @@ public class RSQLJPAPredicateConverter extends RSQLVisitorBase<Predicate, From> 
 
 	private Predicate likePredicate(Expression<?> expression, Object argument, boolean ignoreCase) {
 		String argToUse = String.valueOf(argument);
-		Expression<String> strExpression = expression.as(String.class);
+		Expression<String> strExpression = textualExpression(expression);
 		if (ignoreCase) {
 			if (HibernateSupport.isHibernateCriteriaBuilder(builder)) {
 				return HibernateSupport.ilike(builder, strExpression, argToUse, likeEscapeCharacter);
@@ -426,6 +430,20 @@ public class RSQLJPAPredicateConverter extends RSQLVisitorBase<Predicate, From> 
 		}
 		
 		return likePredicate(strExpression, "%" + argToUse + "%", builder);
+	}
+
+	private Predicate ignoreCasePredicate(Expression<?> expression, Object argument) {
+		Expression<String> strExpression = textualExpression(expression);
+		String argToUse = String.valueOf(argument);
+
+		return builder.equal(builder.upper(strExpression), argToUse.toUpperCase(Locale.ROOT));
+	}
+
+	private Expression<String> textualExpression(Expression<?> expression) {
+		if (expression instanceof JpaExpression<?> jpaExpression) {
+			return jpaExpression.cast(String.class);
+		}
+		return expression.as(String.class);
 	}
 
 	private Predicate equalPredicate(Expression expr, Class type, Object argument) {

--- a/rsql-jpa/src/test/java/io/github/perplexhub/rsql/RSQLJPAPredicateConverterTest.java
+++ b/rsql-jpa/src/test/java/io/github/perplexhub/rsql/RSQLJPAPredicateConverterTest.java
@@ -1,0 +1,40 @@
+package io.github.perplexhub.rsql;
+
+import static io.github.perplexhub.rsql.RSQLOperators.IGNORE_CASE;
+import static io.github.perplexhub.rsql.RSQLOperators.IGNORE_CASE_LIKE;
+import static io.github.perplexhub.rsql.RSQLOperators.IGNORE_CASE_NOT_LIKE;
+import static io.github.perplexhub.rsql.RSQLOperators.LIKE;
+import static io.github.perplexhub.rsql.RSQLOperators.NOT_LIKE;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.util.Set;
+import java.util.stream.Stream;
+
+import cz.jirutka.rsql.parser.ast.ComparisonOperator;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class RSQLJPAPredicateConverterTest {
+
+	private static final Set<ComparisonOperator> TEXTUAL_ARGUMENT_OPERATORS = Set.of(
+			LIKE,
+			NOT_LIKE,
+			IGNORE_CASE,
+			IGNORE_CASE_LIKE,
+			IGNORE_CASE_NOT_LIKE
+	);
+
+	@ParameterizedTest
+	@MethodSource("supportedOperators")
+	void preservesTextualArgumentOnlyMatchesTextualArgumentOperators(ComparisonOperator operator, boolean expected) {
+		assertThat(RSQLJPAPredicateConverter.preservesTextualArgument(operator), is(expected));
+	}
+
+	static Stream<Arguments> supportedOperators() {
+		return RSQLOperators.supportedOperators().stream()
+				.map(operator -> arguments(operator, TEXTUAL_ARGUMENT_OPERATORS.contains(operator)));
+	}
+}

--- a/rsql-jpa/src/test/java/io/github/perplexhub/rsql/RSQLJPASupportPostgresJsonTest.java
+++ b/rsql-jpa/src/test/java/io/github/perplexhub/rsql/RSQLJPASupportPostgresJsonTest.java
@@ -4,10 +4,12 @@ import io.github.perplexhub.rsql.model.AnotherJsonbEntity;
 import io.github.perplexhub.rsql.model.EntityWithJsonb;
 import io.github.perplexhub.rsql.model.JsonbEntity;
 import io.github.perplexhub.rsql.model.PostgresJsonEntity;
+import io.github.perplexhub.rsql.model.User;
 import io.github.perplexhub.rsql.repository.jpa.postgres.AnotherJsonbEntityRepository;
 import io.github.perplexhub.rsql.repository.jpa.postgres.EntityWithJsonbRepository;
 import io.github.perplexhub.rsql.repository.jpa.postgres.JsonbEntityRepository;
 import io.github.perplexhub.rsql.repository.jpa.postgres.PostgresJsonEntityRepository;
+import io.github.perplexhub.rsql.repository.jpa.UserRepository;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -49,6 +51,9 @@ class RSQLJPASupportPostgresJsonTest {
     @Autowired
     private AnotherJsonbEntityRepository anotherJsonbEntityRepository;
 
+    @Autowired
+    private UserRepository userRepository;
+
     @BeforeEach
     void setup(@Autowired EntityManager em) {
         RSQLVisitorBase.setEntityManagerDatabase(Map.of(em, Database.POSTGRESQL));
@@ -62,10 +67,32 @@ class RSQLJPASupportPostgresJsonTest {
     }
 
     private void clear() {
+        userRepository.deleteAll();
+        userRepository.flush();
         repository.deleteAll();
         repository.flush();
         entityWithJsonbRepository.deleteAll();
         entityWithJsonbRepository.flush();
+        jsonbEntityRepository.deleteAll();
+        jsonbEntityRepository.flush();
+        anotherJsonbEntityRepository.deleteAll();
+        anotherJsonbEntityRepository.flush();
+    }
+
+    @Test
+    void testLikeOnUuidFieldWithExactUuid() {
+        UUID externalId = UUID.fromString("11111111-1111-4111-8111-111111111111");
+        User user = new User();
+        user.setName("January");
+        user.setExternalId(externalId);
+        userRepository.saveAndFlush(user);
+
+        List<User> result = userRepository.findAll(toSpecification("externalId=like='11111111-1111-4111-8111-111111111111'"));
+
+        assertThat(result)
+                .hasSize(1)
+                .extracting(User::getExternalId)
+                .containsExactly(externalId);
     }
 
     @ParameterizedTest

--- a/rsql-jpa/src/test/java/io/github/perplexhub/rsql/RSQLJPASupportTest.java
+++ b/rsql-jpa/src/test/java/io/github/perplexhub/rsql/RSQLJPASupportTest.java
@@ -41,6 +41,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -172,6 +173,42 @@ class RSQLJPASupportTest {
 		log.info("rsql: {} -> count: {}", querySupport.getRsqlQuery(), count);
 		assertThat(querySupport.getRsqlQuery(), count, is(1L));
 		assertThat(querySupport.getRsqlQuery(), users.get(0).getName(), equalTo("February"));
+	}
+
+	@Test
+	final void testLikeOnUuidField() {
+		String rsql = "externalId=like='1111-4111'";
+		List<User> users = userRepository.findAll(toSpecification(rsql));
+		long count = users.size();
+		log.info("rsql: {} -> count: {}", rsql, count);
+		assertThat(rsql, count, is(1L));
+		assertThat(rsql, users.get(0).getExternalId(), equalTo(UUID.fromString("11111111-1111-4111-8111-111111111111")));
+	}
+
+	@Test
+	final void testIgnoreCaseLikeOnUuidField() {
+		String rsql = "externalId=ilike='AAAAAAAA'";
+		List<User> users = userRepository.findAll(toSpecification(rsql));
+		long count = users.size();
+		log.info("rsql: {} -> count: {}", rsql, count);
+		assertThat(rsql, count, is(1L));
+		assertThat(rsql, users.get(0).getExternalId(), equalTo(UUID.fromString("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")));
+	}
+
+	@ParameterizedTest
+	@CsvSource({
+			"=like=,1111-4111,1",
+			"=notlike=,1111-4111,1",
+			"=icase=,AAAAAAAA,0",
+			"=ilike=,AAAAAAAA,1",
+			"=inotlike=,AAAAAAAA,1"
+	})
+	final void testTextualOperatorsPreserveRsqlArgumentOnUuidField(String operator, String value, long expectedCount) {
+		String rsql = String.format("externalId%s'%s'", operator, value);
+		List<User> users = userRepository.findAll(toSpecification(rsql));
+		long count = users.size();
+		log.info("rsql: {} -> count: {}", rsql, count);
+		assertThat(rsql, count, is(expectedCount));
 	}
 
 	@Test


### PR DESCRIPTION
Hi @perplexhub, @nstdio,

While using the lib on UUID fields, we ran into an issue with `=ilike=` on UUID attributes.

There are actually two related failure modes:

- partial textual values are converted too early to the Java field type, so a query like `externalId=ilike='AAAAAAAA'` fails with a `ConversionException: Failed to convert ... to java.util.UUID type`;
- on PostgreSQL, even a full UUID value fails because the generated SQL applies `LIKE` directly to a UUID column, which raises `PSQLException: ERROR: operator does not exist: uuid ~~ text`.

This PR keeps the RSQL argument as text for textual operators, and casts the expression side to text when building `LIKE` / `ILIKE` / `ICASE` predicates. With Hibernate/PostgreSQL this now produces the expected SQL shape:

```sql
cast(users.external_id as varchar) like ?
```

I kept the patch narrow and added coverage for:
- the invariant deciding which operators preserve textual arguments;
- UUID fields with `like`, `notlike`, `icase`, `ilike`, `inotlike`;
- the PostgreSQL exact UUID `like` case.

`mvn clean verify` is green locally.

Do you see any potential breaking change with this behavior, especially for existing non-String fields using textual operators?