### PR TITLE
Add per-query ConversionService support

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,8 @@ repository.findAll(toPredicate(filter, QUser.user, propertyPathMapper), pageable
 
 ## Custom Value Converter
 
+Converters registered with `addConverter` are stored in the library-wide conversion service and are shared by the JVM.
+
 ```java
 SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss");
 RSQLJPASupport.addConverter(Date.class, s -> {
@@ -261,6 +263,24 @@ RSQLJPASupport.addConverter(Date.class, s -> {
 		return null;
 	}
 });
+```
+
+## Per-query ConversionService
+
+For applications that need isolated conversion rules, `QuerySupport` can carry a Spring `ConversionService` used only for that query. If no per-query service is supplied, RSQL keeps using the global converters registered through `RSQLJPASupport.addConverter(...)`.
+
+```java
+Specification<User> spec = RSQLJPASupport.toSpecification(QuerySupport.builder()
+	.rsqlQuery("createdAt==2026-06-06")
+	.conversionService(applicationConversionService)
+	.build());
+```
+
+QueryDSL predicates can receive the same per-query service through the four-argument overload:
+
+```java
+BooleanExpression predicate = RSQLQueryDslSupport.toPredicate(
+	filter, QUser.user, propertyPathMapper, applicationConversionService);
 ```
 
 ## Custom Operator & Predicate

--- a/rsql-common/src/main/java/io/github/perplexhub/rsql/RSQLVisitorBase.java
+++ b/rsql-common/src/main/java/io/github/perplexhub/rsql/RSQLVisitorBase.java
@@ -3,7 +3,6 @@ package io.github.perplexhub.rsql;
 import java.lang.reflect.*;
 import java.sql.Timestamp;
 import java.time.*;
-import java.time.format.DateTimeParseException;
 import java.util.*;
 import java.util.Map.Entry;
 
@@ -16,7 +15,7 @@ import jakarta.persistence.metamodel.PluralAttribute;
 import lombok.Getter;
 import org.hibernate.metamodel.model.domain.ManagedDomainType;
 import org.hibernate.metamodel.model.domain.PersistentAttribute;
-import org.springframework.core.convert.ConversionFailedException;
+import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.support.ConfigurableConversionService;
 import org.springframework.orm.jpa.vendor.Database;
 import org.springframework.util.StringUtils;
@@ -42,6 +41,8 @@ public abstract class RSQLVisitorBase<R, A> implements RSQLVisitor<R, A> {
 	protected @Setter Map<Class<?>, List<String>> propertyWhitelist;
 
 	protected @Setter Map<Class<?>, List<String>> propertyBlacklist;
+
+	protected @Setter ConversionService conversionService;
 
 	protected Map<Class, ManagedType> getManagedTypeMap() {
 		return managedTypeMap != null ? managedTypeMap : Collections.emptyMap();
@@ -79,7 +80,9 @@ public abstract class RSQLVisitorBase<R, A> implements RSQLVisitor<R, A> {
 
 		Object object = null;
 		try {
-			if (defaultConversionService.canConvert(String.class, targetType)) {
+			if (conversionService != null && conversionService.canConvert(String.class, targetType)) {
+				object = conversionService.convert(source, targetType);
+			} else if (defaultConversionService != null && defaultConversionService.canConvert(String.class, targetType)) {
 				object = defaultConversionService.convert(source, targetType);
 			} else if (targetType.equals(String.class)) {
 				object = source;

--- a/rsql-common/src/test/java/io/github/perplexhub/rsql/RSQLVisitorBaseTest.java
+++ b/rsql-common/src/test/java/io/github/perplexhub/rsql/RSQLVisitorBaseTest.java
@@ -38,6 +38,11 @@ class RSQLVisitorBaseTest {
     RSQLVisitorBase.setDefaultConversionService(new DefaultConversionService());
   }
 
+  @AfterEach
+  void resetDefaultConversionService() {
+    RSQLVisitorBase.setDefaultConversionService(new DefaultConversionService());
+  }
+
   @Test
   void testConversionException() {
     assertThatExceptionOfType(ConversionException.class)

--- a/rsql-common/src/test/java/io/github/perplexhub/rsql/RSQLVisitorBaseTest.java
+++ b/rsql-common/src/test/java/io/github/perplexhub/rsql/RSQLVisitorBaseTest.java
@@ -4,8 +4,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.InstanceOfAssertFactories.LOCAL_DATE_TIME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -20,6 +22,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.core.convert.support.DefaultConversionService;
 import org.springframework.lang.NonNull;
@@ -40,6 +43,34 @@ class RSQLVisitorBaseTest {
     assertThatExceptionOfType(ConversionException.class)
         .isThrownBy(() -> unit.convert("abc", Integer.class))
         .satisfies(e -> assertEquals("Failed to convert abc to java.lang.Integer type", e.getMessage()));
+  }
+
+  @Test
+  void shouldPreferInstanceConversionServiceOverGlobalConversionService() {
+    ConversionService queryConversionService = mock(ConversionService.class);
+    when(queryConversionService.canConvert(String.class, ConvertedValue.class)).thenReturn(true);
+    when(queryConversionService.convert("abc", ConvertedValue.class))
+        .thenReturn(new ConvertedValue("query:abc"));
+    RSQLVisitorBase.defaultConversionService.addConverter(String.class, ConvertedValue.class,
+        source -> new ConvertedValue("global:" + source));
+    unit.setConversionService(queryConversionService);
+
+    var actual = unit.convert("abc", ConvertedValue.class);
+
+    assertThat(actual).isEqualTo(new ConvertedValue("query:abc"));
+  }
+
+  @Test
+  void shouldFallbackToGlobalConversionServiceWhenInstanceCannotConvert() {
+    ConversionService queryConversionService = mock(ConversionService.class);
+    when(queryConversionService.canConvert(String.class, ConvertedValue.class)).thenReturn(false);
+    RSQLVisitorBase.defaultConversionService.addConverter(String.class, ConvertedValue.class,
+        source -> new ConvertedValue("global:" + source));
+    unit.setConversionService(queryConversionService);
+
+    var actual = unit.convert("abc", ConvertedValue.class);
+
+    assertThat(actual).isEqualTo(new ConvertedValue("global:abc"));
   }
 
   @Nested
@@ -142,4 +173,6 @@ class RSQLVisitorBaseTest {
       return LocalDateTime.parse(source, DateTimeFormatter.ISO_DATE_TIME);
     }
   }
+
+  private record ConvertedValue(String value) {}
 }

--- a/rsql-jpa/src/main/java/io/github/perplexhub/rsql/QuerySupport.java
+++ b/rsql-jpa/src/main/java/io/github/perplexhub/rsql/QuerySupport.java
@@ -4,6 +4,7 @@ import lombok.Builder;
 import lombok.Data;
 
 import jakarta.persistence.criteria.JoinType;
+import org.springframework.core.convert.ConversionService;
 
 import java.util.Collection;
 import java.util.List;
@@ -27,6 +28,7 @@ public class QuerySupport {
     private Map<Class<?>, List<String>> propertyBlacklist;
     private Collection<String> procedureWhiteList;
     private Collection<String> procedureBlackList;
+    private ConversionService conversionService;
     @Builder.Default
     private JsonbConfiguration jsonbConfiguration = JsonbConfiguration.DEFAULT;
 
@@ -34,7 +36,7 @@ public class QuerySupport {
 
     @Override
     public String toString() {
-        return String.format("%s,distinct:%b,propertyPathMapper:%s,customPredicates:%d,joinHints:%s,propertyWhitelist:%s,propertyBlacklist:%s,jsonbConfiguration:%s",
-                rsqlQuery, distinct, propertyPathMapper, customPredicates == null ? 0 : customPredicates.size(), joinHints, propertyWhitelist, propertyBlacklist, jsonbConfiguration);
+        return String.format("%s,distinct:%b,propertyPathMapper:%s,customPredicates:%d,joinHints:%s,propertyWhitelist:%s,propertyBlacklist:%s,conversionService:%s,jsonbConfiguration:%s",
+                rsqlQuery, distinct, propertyPathMapper, customPredicates == null ? 0 : customPredicates.size(), joinHints, propertyWhitelist, propertyBlacklist, conversionService, jsonbConfiguration);
     }
 }

--- a/rsql-jpa/src/main/java/io/github/perplexhub/rsql/RSQLJPAPredicateConverter.java
+++ b/rsql-jpa/src/main/java/io/github/perplexhub/rsql/RSQLJPAPredicateConverter.java
@@ -98,7 +98,7 @@ public class RSQLJPAPredicateConverter extends RSQLVisitorBase<Predicate, From> 
 		this.strictEquality = strictEquality;
 		this.likeEscapeCharacter = likeEscapeCharacter;
         this.jsonbConfiguration = jsonbConfiguration;
-		setConversionService(conversionService);
+		this.conversionService = conversionService;
 	}
 
 	private static <X> Path<X> getPath(Path<X> path, String attribute) {

--- a/rsql-jpa/src/main/java/io/github/perplexhub/rsql/RSQLJPAPredicateConverter.java
+++ b/rsql-jpa/src/main/java/io/github/perplexhub/rsql/RSQLJPAPredicateConverter.java
@@ -22,6 +22,7 @@ import cz.jirutka.rsql.parser.ast.OrNode;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.query.criteria.JpaExpression;
+import org.springframework.core.convert.ConversionService;
 
 @Slf4j
 @SuppressWarnings({ "rawtypes", "unchecked" })
@@ -74,6 +75,20 @@ public class RSQLJPAPredicateConverter extends RSQLVisitorBase<Predicate, From> 
                                      boolean strictEquality,
                                      Character likeEscapeCharacter,
                                      JsonbConfiguration jsonbConfiguration) {
+		this(builder, propertyPathMapper, customPredicates, joinHints, proceduresWhiteList, proceduresBlackList,
+				strictEquality, likeEscapeCharacter, jsonbConfiguration, null);
+	}
+
+	public RSQLJPAPredicateConverter(CriteriaBuilder builder,
+                                     Map<String, String> propertyPathMapper,
+                                     List<RSQLCustomPredicate<?>> customPredicates,
+                                     Map<String, JoinType> joinHints,
+                                     Collection<String> proceduresWhiteList,
+                                     Collection<String> proceduresBlackList,
+                                     boolean strictEquality,
+                                     Character likeEscapeCharacter,
+                                     JsonbConfiguration jsonbConfiguration,
+                                     ConversionService conversionService) {
 		this.builder = builder;
 		this.propertyPathMapper = propertyPathMapper != null ? propertyPathMapper : Collections.emptyMap();
 		this.customPredicates = customPredicates != null ? customPredicates.stream().collect(Collectors.toMap(RSQLCustomPredicate::getOperator, Function.identity(), (a, b) -> a)) : Collections.emptyMap();
@@ -83,6 +98,7 @@ public class RSQLJPAPredicateConverter extends RSQLVisitorBase<Predicate, From> 
 		this.strictEquality = strictEquality;
 		this.likeEscapeCharacter = likeEscapeCharacter;
         this.jsonbConfiguration = jsonbConfiguration;
+		setConversionService(conversionService);
 	}
 
 	private static <X> Path<X> getPath(Path<X> path, String attribute) {

--- a/rsql-jpa/src/main/java/io/github/perplexhub/rsql/RSQLJPASupport.java
+++ b/rsql-jpa/src/main/java/io/github/perplexhub/rsql/RSQLJPASupport.java
@@ -128,7 +128,7 @@ public class RSQLJPASupport extends RSQLCommonSupport {
 					querySupport.getCustomPredicates(), querySupport.getJoinHints(),
 					querySupport.getProcedureWhiteList(), querySupport.getProcedureBlackList(),
 					querySupport.isStrictEquality(), querySupport.getLikeEscapeCharacter(),
-                    querySupport.getJsonbConfiguration());
+                    querySupport.getJsonbConfiguration(), querySupport.getConversionService());
 
 			visitor.setPropertyWhitelist(querySupport.getPropertyWhitelist());
 			visitor.setPropertyBlacklist(querySupport.getPropertyBlacklist());

--- a/rsql-jpa/src/test/java/io/github/perplexhub/rsql/RSQLJPASupportTest.java
+++ b/rsql-jpa/src/test/java/io/github/perplexhub/rsql/RSQLJPASupportTest.java
@@ -8,6 +8,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.sql.Timestamp;
 import java.text.ParseException;
@@ -45,6 +47,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.convert.ConversionService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.domain.Specification;
@@ -173,6 +176,43 @@ class RSQLJPASupportTest {
 		log.info("rsql: {} -> count: {}", querySupport.getRsqlQuery(), count);
 		assertThat(querySupport.getRsqlQuery(), count, is(1L));
 		assertThat(querySupport.getRsqlQuery(), users.get(0).getName(), equalTo("February"));
+	}
+
+	@Test
+	final void testQuerySupportConversionServiceTakesPrecedence() {
+		ConversionService conversionService = mock(ConversionService.class);
+		when(conversionService.canConvert(String.class, Integer.class)).thenReturn(true);
+		when(conversionService.convert("1", Integer.class)).thenReturn(2);
+
+		QuerySupport querySupport = QuerySupport.builder()
+				.rsqlQuery("id==1")
+				.conversionService(conversionService)
+				.build();
+
+		List<User> users = userRepository.findAll(toSpecification(querySupport));
+
+		assertThat(querySupport.getRsqlQuery(), users.size(), is(1));
+		assertThat(querySupport.getRsqlQuery(), users.get(0).getId(), equalTo(2));
+		assertThat(querySupport.getRsqlQuery(), users.get(0).getName(), equalTo("February"));
+	}
+
+	@Test
+	final void testCustomPredicateUsesQuerySupportConversionService() {
+		ConversionService conversionService = mock(ConversionService.class);
+		when(conversionService.canConvert(String.class, Integer.class)).thenReturn(true);
+		when(conversionService.convert("1", Integer.class)).thenReturn(2);
+		RSQLCustomPredicate<Integer> customPredicate = new RSQLCustomPredicate<>(new ComparisonOperator("=shifted="), Integer.class,
+				input -> input.getCriteriaBuilder().equal(input.getPath(), input.getArguments().get(0)));
+		QuerySupport querySupport = QuerySupport.builder()
+				.rsqlQuery("id=shifted=1")
+				.customPredicates(List.of(customPredicate))
+				.conversionService(conversionService)
+				.build();
+
+		List<User> users = userRepository.findAll(toSpecification(querySupport));
+
+		assertThat(querySupport.getRsqlQuery(), users.size(), is(1));
+		assertThat(querySupport.getRsqlQuery(), users.get(0).getId(), equalTo(2));
 	}
 
 	@Test

--- a/rsql-querydsl/src/main/java/io/github/perplexhub/rsql/RSQLQueryDslPredicateConverter.java
+++ b/rsql-querydsl/src/main/java/io/github/perplexhub/rsql/RSQLQueryDslPredicateConverter.java
@@ -22,6 +22,7 @@ import cz.jirutka.rsql.parser.ast.OrNode;
 import lombok.Getter;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.convert.ConversionService;
 
 @Slf4j
 @SuppressWarnings({ "rawtypes", "unchecked" })
@@ -30,8 +31,13 @@ public class RSQLQueryDslPredicateConverter extends RSQLVisitorBase<BooleanExpre
 	private final @Getter Map<String, String> propertyPathMapper;
 
 	public RSQLQueryDslPredicateConverter(Map<String, String> propertyPathMapper) {
+		this(propertyPathMapper, null);
+	}
+
+	public RSQLQueryDslPredicateConverter(Map<String, String> propertyPathMapper, ConversionService conversionService) {
 		super();
 		this.propertyPathMapper = propertyPathMapper != null ? propertyPathMapper : Collections.emptyMap();
+		setConversionService(conversionService);
 	}
 
 	@SneakyThrows

--- a/rsql-querydsl/src/main/java/io/github/perplexhub/rsql/RSQLQueryDslSupport.java
+++ b/rsql-querydsl/src/main/java/io/github/perplexhub/rsql/RSQLQueryDslSupport.java
@@ -5,6 +5,7 @@ import java.util.Properties;
 
 import jakarta.persistence.EntityManager;
 
+import org.springframework.core.convert.ConversionService;
 import org.springframework.util.StringUtils;
 
 import com.querydsl.core.types.Path;
@@ -30,11 +31,15 @@ public class RSQLQueryDslSupport extends RSQLJPASupport {
 	}
 
 	public static BooleanExpression toPredicate(final String rsqlQuery, final Path qClazz, final Map<String, String> propertyPathMapper) {
+		return toPredicate(rsqlQuery, qClazz, propertyPathMapper, null);
+	}
+
+	public static BooleanExpression toPredicate(final String rsqlQuery, final Path qClazz, final Map<String, String> propertyPathMapper, final ConversionService conversionService) {
 		log.debug("toPredicate({},qClazz:{},propertyPathMapper:{})", rsqlQuery, qClazz);
 		if (StringUtils.hasText(rsqlQuery)) {
 			return new RSQLParser(RSQLOperators.supportedOperators())
 					.parse(rsqlQuery)
-					.accept(new RSQLQueryDslPredicateConverter(propertyPathMapper), qClazz);
+					.accept(new RSQLQueryDslPredicateConverter(propertyPathMapper, conversionService), qClazz);
 		} else {
 			return null;
 		}

--- a/rsql-querydsl/src/main/java/io/github/perplexhub/rsql/RSQLQueryDslSupport.java
+++ b/rsql-querydsl/src/main/java/io/github/perplexhub/rsql/RSQLQueryDslSupport.java
@@ -35,7 +35,7 @@ public class RSQLQueryDslSupport extends RSQLJPASupport {
 	}
 
 	public static BooleanExpression toPredicate(final String rsqlQuery, final Path qClazz, final Map<String, String> propertyPathMapper, final ConversionService conversionService) {
-		log.debug("toPredicate({},qClazz:{},propertyPathMapper:{})", rsqlQuery, qClazz);
+		log.debug("toPredicate({}, qClazz:{}, propertyPathMapper:{}, conversionService:{})", rsqlQuery, qClazz, propertyPathMapper, conversionService);
 		if (StringUtils.hasText(rsqlQuery)) {
 			return new RSQLParser(RSQLOperators.supportedOperators())
 					.parse(rsqlQuery)

--- a/rsql-querydsl/src/test/java/io/github/perplexhub/rsql/RSQLQueryDslSupportTest.java
+++ b/rsql-querydsl/src/test/java/io/github/perplexhub/rsql/RSQLQueryDslSupportTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -45,7 +46,8 @@ class RSQLQueryDslSupportTest {
 		when(conversionService.convert("1", Integer.class)).thenReturn(2);
 
 		String rsql = "id==1";
-		List<User> users = (List<User>) userRepository.findAll(toPredicate(rsql, QUser.user, null, conversionService));
+		List<User> users = new ArrayList<>();
+		userRepository.findAll(toPredicate(rsql, QUser.user, null, conversionService)).forEach(users::add);
 
 		assertThat(rsql, users.size(), is(1));
 		assertThat(rsql, users.get(0).getId(), equalTo(2));

--- a/rsql-querydsl/src/test/java/io/github/perplexhub/rsql/RSQLQueryDslSupportTest.java
+++ b/rsql-querydsl/src/test/java/io/github/perplexhub/rsql/RSQLQueryDslSupportTest.java
@@ -6,6 +6,8 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
 import java.util.HashMap;
@@ -15,6 +17,7 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.convert.ConversionService;
 
 import io.github.perplexhub.rsql.model.*;
 import io.github.perplexhub.rsql.repository.querydsl.CompanyRepository;
@@ -34,6 +37,20 @@ class RSQLQueryDslSupportTest {
 
 	@Autowired
 	private TrunkGroupRepository trunkGroupRepository;
+
+	@Test
+	final void testConversionServiceTakesPrecedence() {
+		ConversionService conversionService = mock(ConversionService.class);
+		when(conversionService.canConvert(String.class, Integer.class)).thenReturn(true);
+		when(conversionService.convert("1", Integer.class)).thenReturn(2);
+
+		String rsql = "id==1";
+		List<User> users = (List<User>) userRepository.findAll(toPredicate(rsql, QUser.user, null, conversionService));
+
+		assertThat(rsql, users.size(), is(1));
+		assertThat(rsql, users.get(0).getId(), equalTo(2));
+		assertThat(rsql, users.get(0).getName(), equalTo("February"));
+	}
 
 	@Test
 	final void testQueryMultiLevelAttribute() {


### PR DESCRIPTION
### Resume

This PR adds optional per-query `ConversionService` support for RSQL predicate conversion.

Today, custom value converters are registered through `RSQLJPASupport.addConverter(...)`, which mutates the static conversion service owned by `RSQLCommonSupport`. That works for simple applications, but it makes conversion rules JVM-global. Applications that run multiple Spring contexts, execute tests in parallel, use application-specific value objects, or validate RSQL before delegating execution cannot guarantee that the conversion rules used during validation are the same rules used later by `Specification.toPredicate(...)`.

The change keeps the current global converter registry as the backward-compatible fallback, while allowing callers to pass a query-specific `ConversionService`:

```java
Specification<User> spec = RSQLJPASupport.toSpecification(QuerySupport.builder()
    .rsqlQuery("customerId==ACME-42")
    .propertyPathMapper(paths)
    .conversionService(applicationConversionService)
    .build());
```

Conversion now follows this order:

1. Query or visitor instance `ConversionService`, when present and able to convert.
2. Existing global `defaultConversionService`, preserving `addConverter(...)` behavior.
3. Existing built-in conversion fallbacks.

The same conversion path is used by default JPA operators and JPA custom predicates. QueryDSL also gets a new overload that accepts a per-query `ConversionService`.

### Evidence

> Not required

### Reference

Closes perplexhub/rsql-jpa-specification#207
